### PR TITLE
adds command for cancelling a release that have incomplete human tasks

### DIFF
--- a/releasewarrior/cli.py
+++ b/releasewarrior/cli.py
@@ -139,6 +139,7 @@ def issue(product, version, resolve, logger=LOGGER, config=CONFIG):
     data = order_data(data)
     write_and_commit(data, data_path, wiki_path, commit_msg, logger, config)
 
+
 # TODO assign default date to the "next wed"
 # TODO accept various date inputs
 @cli.command()
@@ -187,7 +188,7 @@ def postmortem(date, logger=LOGGER, config=CONFIG):
 
     # archive completed releases
     for release in completed_releases:
-        _, data_path, wiki_path, __ = get_release_info(release["product"], release["version"],
+        _, data_path, wiki_path = get_release_info(release["product"], release["version"],
                                                        logger, config)
         # add release to postmortem data
         postmortem_data["complete_releases"].append(generate_release_postmortem_data(release))
@@ -202,6 +203,25 @@ def postmortem(date, logger=LOGGER, config=CONFIG):
                                                     key=lambda x: x["date"])
     write_and_commit(postmortem_data, postmortem_data_path, postmortem_wiki_path,
                      commit_msg, logger, config, wiki_template=wiki_template)
+
+
+@cli.command()
+@click.argument('product', type=click.Choice(['firefox', 'devedition', 'fennec', 'thunderbird']))
+@click.argument('version')
+def cancel(product, version, logger=LOGGER, config=CONFIG):
+    """Similar to newbuild where it aborts current buildnum of given release but does not create
+    a new build.
+    """
+    release, data_path, wiki_path = get_release_info(product, version, logger, config)
+    validate(release, logger, config, must_exist=True, must_exist_in="inflight")
+    data = load_json(data_path)
+
+    logger.info("Most recent buildnum has been aborted. Release cancelled.")
+    commit_msg = "{} {} - cancelling release".format(product, version)
+    current_build_index = get_current_build_index(data)
+    data["inflight"][current_build_index]["aborted"] = True
+
+    write_and_commit(data, data_path, wiki_path, commit_msg, logger, config)
 
 
 @cli.command()
@@ -274,6 +294,3 @@ def status(verbose, logger=LOGGER, config=CONFIG):
         for release in complete_releases:
             log_release_status(release, logger)
     ###
-
-# TODO postmortem
-# TODO cancel

--- a/releasewarrior/wiki_data.py
+++ b/releasewarrior/wiki_data.py
@@ -25,10 +25,13 @@ def order_data(data):
 
 
 def get_current_build_index(release):
+    highest_buildnum = 0
+    return_index = 0
     for index, build in enumerate(release['inflight']):
-        if not build["aborted"]:
-            return index
-    return None
+        if build["buildnum"] > highest_buildnum:
+            highest_buildnum = build["buildnum"]
+            return_index = index
+    return return_index
 
 
 def generate_wiki(data, wiki_template, logger, config):
@@ -83,13 +86,13 @@ def get_release_files(release, logging, config):
         os.path.join(release_path, wiki_file)
     ]
 
-def complete_filter(tasks):
-    return all(task["resolved"] for task in tasks)
+def complete_filter(tasks, aborted):
+    return all(task["resolved"] for task in tasks) or aborted
 
-def incomplete_filter(tasks):
-    return not all(task["resolved"] for task in tasks)
+def incomplete_filter(tasks, aborted):
+    return not all(task["resolved"] for task in tasks) and not aborted
 
-def no_filter(tasks):
+def no_filter(tasks, aborted):
     return True
 
 def get_releases(config, logger, inflight=True, filter=no_filter):
@@ -102,9 +105,11 @@ def get_releases(config, logger, inflight=True, filter=no_filter):
                     data = json.load(data_f)
                     if inflight:
                         tasks = data["inflight"][get_current_build_index(data)]["human_tasks"]
+                        aborted = data["inflight"][get_current_build_index(data)]["aborted"]
                     else:
                         tasks = data["preflight"]["human_tasks"]
-                    if filter(tasks):
+                        aborted = False
+                    if filter(tasks, aborted):
                         yield data
 
 


### PR DESCRIPTION
@srfraser @Callek what do you think?

After running:

`release cancel firefox 52.5.1esr`

It committed: https://github.com/mozilla-releng/releasewarrior-data/commit/556acd045d9715ff7eed3778a23933442a16d5d7

and the release was hidden from `release status`.

I then ran:

`release postmortem 2017-12-06`

and it committed: https://github.com/mozilla-releng/releasewarrior-data/commit/52ebbc034bb9ca510813bc464d4f611ab9d024f5