### PR TITLE
Remove 'email candidates' step for Fennec 58 on beta

### DIFF
--- a/releasewarrior/templates/corsica/fennec_beta_progress.template.html
+++ b/releasewarrior/templates/corsica/fennec_beta_progress.template.html
@@ -5,12 +5,12 @@
 {% else %}
   <div class="progress-bar bg-white text-muted" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">Release kick off</div>
 {% endif %}
-{% if releases["fennec"]["beta"]["human_tasks"]["candidates"] %}
+{% if releases["fennec"]["beta"]["human_tasks"]["pushapk"] %}
   <div class="progress-bar bg-primary" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">Uploaded builds</div>
 {% else %}
   <div class="progress-bar bg-white text-muted" role="progressbar" style="width: 25%" aria-valuenow="225 aria-valuemin="0" aria-valuemax="100">Upload builds</div>
 {% endif %}
-{% if releases["fennec"]["beta"]["human_tasks"]["candidates"] %}
+{% if releases["fennec"]["beta"]["human_tasks"]["pushapk"] %}
   <div class="progress-bar bg-primary" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">QE signed off</div>
 {% else %}
   <div class="progress-bar bg-white text-muted" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">QE sign off</div>

--- a/releasewarrior/templates/fennec/beta.json.tmpl
+++ b/releasewarrior/templates/fennec/beta.json.tmpl
@@ -17,12 +17,6 @@
                 "resolved": false
             },
             {
-                "alias": "candidates",
-                "description": "emailed candidates",
-                "docs": "",
-                "resolved": false
-            },
-            {
                 "alias": "pushapk",
                 "description": "run pushapk",
                 "docs": "https://github.com/mozilla/releasewarrior/blob/master/how-tos/fennec-temp-relpro.md#run-pushapk-manually",


### PR DESCRIPTION
Bug 1417731 added automated emails once the graph has built and moved everything into the candidates directory, so this push 
* removes that task from the template
* updates the corsica template to depend on the next task (pushapk)

I'll need to do the same for Fennec 58 on release, but lets make this is correct first.