### PR TITLE
Taskcluster integration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+# See http://pep8.readthedocs.io/en/latest/intro.html#configuration
+ignore = E121, E123, E126, E129, E133, E226, E241, E242, E704, W503, E402
+max-line-length = 99

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,0 +1,29 @@
+version: 0
+tasks:
+  - provisionerId: '{{ taskcluster.docker.provisionerId }}'
+    workerType: '{{ taskcluster.docker.workerType }}'
+    extra:
+      github:
+        events:
+          - pull_request.opened
+          - pull_request.reopened
+          - pull_request.synchronize
+          - push
+    payload:
+      maxRunTime: 3600
+      image: python
+      command:
+        - /bin/bash
+        - '--login'
+        - '-c'
+        - >-
+          git clone {{event.head.repo.url}} repo && cd repo && git config
+          advice.detachedHead false && git checkout {{event.head.sha}} && pip3
+          install flake8 && flake8 . || true
+    metadata:
+      name: 'flake8'
+      description: 'flake8 linting'
+      owner: '{{ event.head.user.email }}'
+      source: '{{ event.head.repo.url }}'
+allowPullRequests: public
+


### PR DESCRIPTION
Add flake8 support for releasewarrior-2.0; don't actually fix flake8 issues (make the test always pass for now)

We'll need to enable taskcluster integration on mozilla-releng/releasewarrior-2.0 (ala https://tools.taskcluster.net/quickstart/ )