### PR TITLE
'release newbuild' should not mark the new build as aborted, even if previous build is already aborted.

### DIFF
--- a/releasewarrior/wiki_data.py
+++ b/releasewarrior/wiki_data.py
@@ -191,6 +191,7 @@ def generate_newbuild_data(data, graphid, release, data_path, wiki_path, logger,
         newbuild = deepcopy(data["inflight"][current_build_index])
         # abort the now previous buildnum
         data["inflight"][current_build_index]["aborted"] = True
+        newbuild["aborted"] = False
         for task in newbuild["human_tasks"]:
             if task["alias"] == "shipit":
                 continue  # leave submitted to shipit as resolved


### PR DESCRIPTION
This fixes issue #35.

I tested using the STR for both before and after.