### PR TITLE
Rw doc linking update

### DIFF
--- a/releasewarrior/templates/corsica/fennec_release_progress.template.html
+++ b/releasewarrior/templates/corsica/fennec_release_progress.template.html
@@ -10,11 +10,6 @@
   {% else %}
   <div class="progress-bar bg-white text-muted" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">Upload builds</div>
   {% endif %}
-  {% if releases["fennec"]["release"]["human_tasks"]["candidates"] %}
-  <div class="progress-bar bg-primary" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">QE signed off</div>
-  {% else %}
-  <div class="progress-bar bg-white text-muted" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">QE sign off</div>
-  {% endif %}
   {% if releases["fennec"]["release"]["human_tasks"]["pushapk"] %}
   <div class="progress-bar bg-primary" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">Published on Google Play</div>
   {% else %}

--- a/releasewarrior/templates/fennec/beta.json.tmpl
+++ b/releasewarrior/templates/fennec/beta.json.tmpl
@@ -19,7 +19,7 @@
             {
                 "alias": "pushapk",
                 "description": "run pushapk",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/fennec-temp-relpro.md",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Push-to-Google-Play#what-to-do",
                 "resolved": false
              },
              {

--- a/releasewarrior/templates/fennec/beta.json.tmpl
+++ b/releasewarrior/templates/fennec/beta.json.tmpl
@@ -21,12 +21,6 @@
                 "description": "run pushapk",
                 "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Push-to-Google-Play#what-to-do",
                 "resolved": false
-             },
-             {
-                "alias": "publish",
-                "description": "published release tasks",
-                "docs": "https://wiki.mozilla.org/Release:Release_Automation_on_Mercurial:Updates_through_Shipping#Post-release_tasks",
-                "resolved": false
              }
         ],
         "issues": [ ]

--- a/releasewarrior/templates/fennec/release.json.tmpl
+++ b/releasewarrior/templates/fennec/release.json.tmpl
@@ -17,12 +17,6 @@
                 "resolved": false
             },
             {
-                "alias": "candidates",
-                "description": "emailed candidates",
-                "docs": "",
-                "resolved": false
-            },
-            {
                 "alias": "pushapk",
                 "description": "run pushapk (out of tree relpro)",
                 "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/relpro.md#3-push-to-releases-dir-mirrors",

--- a/releasewarrior/templates/fennec/release.json.tmpl
+++ b/releasewarrior/templates/fennec/release.json.tmpl
@@ -21,12 +21,6 @@
                 "description": "run pushapk (out of tree relpro)",
                 "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/relpro.md#3-push-to-releases-dir-mirrors",
                 "resolved": false
-             },
-             {
-                "alias": "publish",
-                "description": "published release tasks",
-                "docs": "https://wiki.mozilla.org/Release:Release_Automation_on_Mercurial:Updates_through_Shipping#Post-release_tasks",
-                "resolved": false
              }
         ],
         "issues": [ ]

--- a/releasewarrior/templates/firefox/beta.json.tmpl
+++ b/releasewarrior/templates/firefox/beta.json.tmpl
@@ -25,7 +25,7 @@
              {
                 "alias": "signoff",
                 "description": "signoff in Balrog",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/relpro.md#3-signoffs",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#obtain-sign-offs-for-changes",
                 "resolved": false
              }
         ],

--- a/releasewarrior/templates/firefox/beta.json.tmpl
+++ b/releasewarrior/templates/firefox/beta.json.tmpl
@@ -19,7 +19,7 @@
             {
                 "alias": "publish",
                 "description": "publish release tasks",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/relpro.md#4-publish-release",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#publish-the-release",
                 "resolved": false
              },
              {

--- a/releasewarrior/templates/firefox/devedition.json.tmpl
+++ b/releasewarrior/templates/firefox/devedition.json.tmpl
@@ -25,7 +25,7 @@
              {
                 "alias": "signoff",
                 "description": "signoff in Balrog",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/relpro.md#3-signoffs",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#obtain-sign-offs-for-changes",
                 "resolved": false
              }
         ],

--- a/releasewarrior/templates/firefox/devedition.json.tmpl
+++ b/releasewarrior/templates/firefox/devedition.json.tmpl
@@ -19,7 +19,7 @@
             {
                 "alias": "publish",
                 "description": "publish release tasks",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/relpro.md#4-publish-release",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#publish-the-release",
                 "resolved": false
              },
              {

--- a/releasewarrior/templates/firefox/release-rc.json.tmpl
+++ b/releasewarrior/templates/firefox/release-rc.json.tmpl
@@ -19,7 +19,7 @@
             {
                 "alias": "beta",
                 "description": "publish in Balrog on beta channel",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/relpro.md#4-publish-release",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#publish-the-release",
                 "resolved": false
             },
             {
@@ -43,7 +43,7 @@
             {
                 "alias": "publish",
                 "description": "publish release tasks",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/relpro.md#4-publish-release",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#publish-the-release",
                 "resolved": false
              },
              {

--- a/releasewarrior/templates/firefox/release-rc.json.tmpl
+++ b/releasewarrior/templates/firefox/release-rc.json.tmpl
@@ -37,7 +37,7 @@
             {
                 "alias": "mirrors",
                 "description": "pushed to mirrors/releases",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/relpro.md#2-push-to-releases-dir-mirrors",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#push-artifacts-to-releases-directory",
                 "resolved": false
             },
             {

--- a/releasewarrior/templates/firefox/release-rc.json.tmpl
+++ b/releasewarrior/templates/firefox/release-rc.json.tmpl
@@ -25,7 +25,7 @@
             {
                 "alias": "betasignoff",
                 "description": "signoff in Balrog",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/relpro.md#3-signoffs",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#obtain-sign-offs-for-changes",
                 "resolved": false
             },
             {
@@ -49,7 +49,7 @@
              {
                 "alias": "signoff",
                 "description": "signoff in Balrog",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/relpro.md#3-signoffs",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#obtain-sign-offs-for-changes",
                 "resolved": false
              }
         ],

--- a/releasewarrior/templates/firefox/release.json.tmpl
+++ b/releasewarrior/templates/firefox/release.json.tmpl
@@ -25,7 +25,7 @@
             {
                 "alias": "mirrors",
                 "description": "pushed to mirrors/releases",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/relpro.md#2-push-to-releases-dir-mirrors",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#push-artifacts-to-releases-directory",
                 "resolved": false
             },
             {

--- a/releasewarrior/templates/firefox/release.json.tmpl
+++ b/releasewarrior/templates/firefox/release.json.tmpl
@@ -31,7 +31,7 @@
             {
                 "alias": "publish",
                 "description": "publish release tasks",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/relpro.md#4-publish-release",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#publish-the-release",
                 "resolved": false
              },
              {

--- a/releasewarrior/templates/firefox/release.json.tmpl
+++ b/releasewarrior/templates/firefox/release.json.tmpl
@@ -37,7 +37,7 @@
              {
                 "alias": "signoff",
                 "description": "signoff in Balrog",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/relpro.md#3-signoffs",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#obtain-sign-offs-for-changes",
                 "resolved": false
              }
         ],

--- a/releasewarrior/templates/thunderbird/beta.json.tmpl
+++ b/releasewarrior/templates/thunderbird/beta.json.tmpl
@@ -25,7 +25,7 @@
              {
                 "alias": "signoff",
                 "description": "signoff in Balrog",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/relpro.md#3-signoffs",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#obtain-sign-offs-for-changes",
                 "resolved": false
              },
              {

--- a/releasewarrior/templates/thunderbird/release.json.tmpl
+++ b/releasewarrior/templates/thunderbird/release.json.tmpl
@@ -31,7 +31,7 @@
              {
                 "alias": "signoff",
                 "description": "signoff in Balrog",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/relpro.md#3-signoffs",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#obtain-sign-offs-for-changes",
                 "resolved": false
              },
              {


### PR DESCRIPTION
This is built ontop of PR #39 and explicitly doesn't affect fennec release (since its not in-tree relpro) and doesn't affect ESR docs at this time.

(once PR #39 merges, I'll rebase this to `master` to get a clean PR here)