### PR TITLE
Gather tasks

### DIFF
--- a/extra-requirements-scripts.txt
+++ b/extra-requirements-scripts.txt
@@ -1,0 +1,2 @@
+aiohttp
+taskcluster

--- a/scripts/get_graphids.py
+++ b/scripts/get_graphids.py
@@ -1,0 +1,160 @@
+#! /usr/env python3
+
+import argparse
+import aiohttp
+import asyncio
+import async_timeout
+import posixpath
+from taskcluster.async import Index
+from taskcluster.async import Queue
+
+
+HG_URL = 'https://hg.mozilla.org/'
+
+REPOS = ('releases/mozilla-beta', 'releases/mozilla-release',
+         'releases/mozilla-esr52', 'mozilla-central')
+
+""" http://mozilla-version-control-tools.readthedocs.io/en/latest/hgmo/pushlog.html?highlight=json-pushes#json-pushes-command """  # noqa
+JSON_PUSHES = 'json-pushes?changeset={rev}'
+
+ACTION_INDEX = 'gecko.v2.{repo}.pushlog-id.{pushid}.actions'
+
+
+async def get_changeset_data(revision, session):
+    for repo in REPOS:
+        url = posixpath.join(HG_URL, repo, JSON_PUSHES.format(rev=revision))
+        async with async_timeout.timeout(10):
+            async with session.get(url) as response:
+                if response.status == 404:
+                    continue
+                response.raise_for_status()
+
+                index_repo = repo[repo.rfind('/') + 1:]
+                data = await response.json()
+                pushlog_id = list(data.keys())[0]
+                changeset = data[pushlog_id]['changesets'][-1]
+                return (changeset, index_repo, pushlog_id)
+
+
+async def get_action_tasks(session, pushlog_id, index_repo):
+    async with async_timeout.timeout(100):
+        index_string = ACTION_INDEX.format(pushid=pushlog_id, repo=index_repo)
+        index = Index(session=session)
+        data = await index.listTasks(index_string, dict(limit=100))
+        tasks = [t['taskId'] for t in data['tasks']]
+        return tasks
+
+
+async def get_action_task_details(session, taskid):
+    async with async_timeout.timeout(100):
+        queue = Queue(session=session)
+        task = await queue.task(taskid)
+        return dict(taskid=taskid,
+                    name=task['extra']['action']['name'],
+                    buildnum=task['extra']['action']['context']['input']['build_number'],
+                    flavor=task['extra']['action']['context']['input']['release_promotion_flavor'],
+                    ci=task['taskGroupId'])
+
+
+def output_graphs(tasks, format='human'):
+    if format == 'human':
+        return output_graphs_human(tasks)
+    if format == 'export':
+        return output_graphs_export(tasks)
+    raise NotImplementedError("format {} is not yet implemented".format(format))
+
+
+def output_graphs_human(tasks):
+    for product in ['devedition', 'firefox', 'fennec']:
+        product_tasks = [t for t in tasks if product in t['flavor']]
+        if not product_tasks:
+            continue
+        buildnumbers = set([t['buildnum'] for t in product_tasks])
+        print("|{:-^111}|".format(product.title()))
+        print("|  {:<8} | {:^22} | {:^22} | {:^22} | {:^22} |".format(
+            'buildN', 'CI', 'promote', 'push', 'ship'))
+        print("|{:-^111}|".format(''))
+        for bn in sorted(buildnumbers, reverse=True):
+            for ci in set([t['ci'] for t in product_tasks if t['buildnum'] == bn]):
+                promote = [t['taskid'] for t in product_tasks
+                           if t['buildnum'] == bn and t['ci'] == ci and
+                           'promote_' in t['flavor']]
+                push = [t['taskid'] for t in product_tasks
+                        if t['buildnum'] == bn and t['ci'] == ci and
+                        'push_' in t['flavor']]
+                ship = [t['taskid'] for t in product_tasks
+                        if t['buildnum'] == bn and t['ci'] == ci and
+                        'ship_' in t['flavor']]
+                if len(promote) > 1 or len(push) > 1 or len(ship) > 1:
+                    raise Exception("Found too many relevant graphs")
+                if not promote:
+                    promote = ['']
+                if not push:
+                    push = ['']
+                if not ship:
+                    ship = ['']
+                print("|  build{:<3} | {:^22} | {:^22} | {:^22} | {:^22} |".format(
+                    bn, ci, promote[0], push[0], ship[0]))
+                print("|{:-^111}|".format(''))
+        print()
+
+
+def output_graphs_export(tasks):
+    for product in ['devedition', 'firefox', 'fennec']:
+        product_tasks = [t for t in tasks if product in t['flavor']]
+        if not product_tasks:
+            continue
+        buildnumbers = set([t['buildnum'] for t in product_tasks])
+        print("|{:-^80}|".format(product.title()))
+        for bn in sorted(buildnumbers, reverse=True):
+            for ci in set([t['ci'] for t in product_tasks if t['buildnum'] == bn]):
+                print("|{:.^80}|".format('build{}'.format(bn)))
+                promote = [t['taskid'] for t in product_tasks
+                           if t['buildnum'] == bn and t['ci'] == ci and
+                           'promote_' in t['flavor']]
+                push = [t['taskid'] for t in product_tasks
+                        if t['buildnum'] == bn and t['ci'] == ci and
+                        'push_' in t['flavor']]
+                ship = [t['taskid'] for t in product_tasks
+                        if t['buildnum'] == bn and t['ci'] == ci and
+                        'ship_' in t['flavor']]
+                if len(promote) > 1 or len(push) > 1 or len(ship) > 1:
+                    raise Exception("Found too many relevant graphs")
+                print('export DECISION_TASK_ID={}'.format(ci))
+                if promote:
+                    print('export PROMOTE_TASK_ID={}'.format(promote[0]))
+                if push:
+                    print('export PUSH_TASK_ID={}'.format(push[0]))
+                if ship:
+                    print('export SHIP_TASK_ID={}'.format(ship[0]))
+                print("|{:-^80}|".format(''))
+        print()
+
+
+def get_my_options():
+    parser = argparse.ArgumentParser(description='Gather taskids for release promotion')
+    parser.add_argument('-r', '--revision', action='store')
+    parser.add_argument('--output', default='human', action='store',
+                        choices=['human', 'export'])
+    options = parser.parse_args()
+    return options
+
+
+async def main(loop):
+    async with aiohttp.ClientSession(loop=loop) as session:
+        options = get_my_options()
+        cset_data = await get_changeset_data(options.revision, session)
+        changeset, index_repo, pushlog_id = cset_data
+        possible_tasks = await get_action_tasks(session, pushlog_id, index_repo)
+        all_relevant_tasks = []
+        for taskid in possible_tasks:
+            task_data = await get_action_task_details(session, taskid)
+            if task_data['name'] != 'release-promotion':
+                continue
+            all_relevant_tasks.append(task_data)
+        output_graphs(all_relevant_tasks, format=options.output)
+
+
+if __name__ == '__main__':
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main(loop))

--- a/scripts/get_graphids.py
+++ b/scripts/get_graphids.py
@@ -1,7 +1,7 @@
-#! /usr/env python3
+#!/usr/bin/env python
 
-import argparse
 import aiohttp
+import argparse
 import asyncio
 import async_timeout
 import posixpath
@@ -15,7 +15,7 @@ REPOS = ('releases/mozilla-beta', 'releases/mozilla-release',
          'releases/mozilla-esr52', 'mozilla-central')
 
 """ http://mozilla-version-control-tools.readthedocs.io/en/latest/hgmo/pushlog.html?highlight=json-pushes#json-pushes-command """  # noqa
-JSON_PUSHES = 'json-pushes?changeset={rev}'
+JSON_PUSHES = 'json-pushes?changeset={rev}&version=2&tipsonly=1&full=1'
 
 ACTION_INDEX = 'gecko.v2.{repo}.pushlog-id.{pushid}.actions'
 
@@ -31,8 +31,8 @@ async def get_changeset_data(revision, session):
 
                 index_repo = repo[repo.rfind('/') + 1:]
                 data = await response.json()
-                pushlog_id = list(data.keys())[0]
-                changeset = data[pushlog_id]['changesets'][-1]
+                pushlog_id = list(data['pushes'].keys())[0]
+                changeset = data['pushes'][pushlog_id]['changesets'][-1]
                 return (changeset, index_repo, pushlog_id)
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 from setuptools import setup, find_packages
 
 requirements = open("requirements.txt").readlines()
+extra_requirements = {
+    'scripts': open("extra-requirements-scripts.txt").readlines()
+}
 version = open("version.txt").readline()
 
 setup(
@@ -9,6 +12,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=requirements,
+    extras_require=extra_requirements,
     entry_points="""
         [console_scripts]
         release=releasewarrior.cli:cli


### PR DESCRIPTION
This is first-round at giving a useful gather tasks script. It works by passing in --revision (from any releasy tree) and outputting action tasks in either human form or export form. Future improvements can be to pass in a random taskID from the CI or release graph and find this info without a revision as first input.

I'm particular partial to review of my await/async syntax since this is one of my first uses of that.

Additionally I added `taskcluster` and `aiohttp` to the extras_require section, since its not needed for main releasewarrior2 functionality, but is needed for this script.  `pip install -U -e .['scripts']` works for this locally.