### PR TITLE
Updates to templates for in tree release tasks.

### DIFF
--- a/releasewarrior/templates/fennec/release.json.tmpl
+++ b/releasewarrior/templates/fennec/release.json.tmpl
@@ -18,8 +18,8 @@
             },
             {
                 "alias": "pushapk",
-                "description": "run pushapk (out of tree relpro)",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/relpro.md#3-push-to-releases-dir-mirrors",
+                "description": "run pushapk",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Push-to-Google-Play#what-to-do",
                 "resolved": false
              }
         ],

--- a/releasewarrior/templates/firefox/beta.json.tmpl
+++ b/releasewarrior/templates/firefox/beta.json.tmpl
@@ -21,7 +21,7 @@
                 "description": "pushed to mirrors/releases",
                 "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks-TC#push-artifacts-to-releases-directory",
                 "resolved": false
-             },
+            },
             {
                 "alias": "publish",
                 "description": "publish release tasks",

--- a/releasewarrior/templates/firefox/release-rc.json.tmpl
+++ b/releasewarrior/templates/firefox/release-rc.json.tmpl
@@ -19,13 +19,13 @@
             {
                 "alias": "beta",
                 "description": "publish in Balrog on beta channel",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#publish-the-release",
+                "docs": "TODO - when they exist",
                 "resolved": false
             },
             {
                 "alias": "betasignoff",
                 "description": "signoff in Balrog",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#obtain-sign-offs-for-changes",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks-TC#obtain-sign-offs-for-changes",
                 "resolved": false
             },
             {
@@ -37,21 +37,21 @@
             {
                 "alias": "mirrors",
                 "description": "pushed to mirrors/releases",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#push-artifacts-to-releases-directory",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks-TC#push-artifacts-to-releases-directory",
                 "resolved": false
             },
             {
                 "alias": "publish",
                 "description": "publish release tasks",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#publish-the-release",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks-TC#ship-the-release",
                 "resolved": false
-             },
-             {
+            },
+            {
                 "alias": "signoff",
                 "description": "signoff in Balrog",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#obtain-sign-offs-for-changes",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks-TC#obtain-sign-offs-for-changes",
                 "resolved": false
-             }
+            }
         ],
         "issues": [ ]
     }]

--- a/releasewarrior/templates/firefox/release.json.tmpl
+++ b/releasewarrior/templates/firefox/release.json.tmpl
@@ -25,21 +25,21 @@
             {
                 "alias": "mirrors",
                 "description": "pushed to mirrors/releases",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#push-artifacts-to-releases-directory",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks-TC#push-artifacts-to-releases-directory",
                 "resolved": false
             },
             {
                 "alias": "publish",
                 "description": "publish release tasks",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#publish-the-release",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks-TC#ship-the-release",
                 "resolved": false
-             },
-             {
+            },
+            {
                 "alias": "signoff",
                 "description": "signoff in Balrog",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#obtain-sign-offs-for-changes",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks-TC#obtain-sign-offs-for-changes",
                 "resolved": false
-             }
+            }
         ],
         "issues": [ ]
     }]


### PR DESCRIPTION
I _think_ this covers everything except ESR. The beta publishing for RC docs don't exist yet, so they're a TODO before this is mergable.