### PR TITLE
fixes fennec m-r templates to point to temp old docs during 58 cycle

### DIFF
--- a/releasewarrior/templates/fennec/release.json.tmpl
+++ b/releasewarrior/templates/fennec/release.json.tmpl
@@ -18,8 +18,8 @@
             },
             {
                 "alias": "pushapk",
-                "description": "run pushapk (out of tree relpro)",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/relpro.md#3-push-to-releases-dir-mirrors",
+                "description": "run pushapk (temp in-tree relpro)",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/fennec-temp-relpro.md#kick-off-publish-action-task",
                 "resolved": false
              }
         ],


### PR DESCRIPTION
@mozbhearsum this is just so we at least still tell the truth for current templates as per: https://github.com/mozilla-releng/releasewarrior-2.0/pull/57#discussion_r165218294