### PR TITLE
Bring docs back to warrior

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ _**As releaseduty squirrels are the ones with the best context when it comes to 
 ## During 59.0 >= 2018-01-24
 
 ### Added
-- we track all major changes in this newly added [CHANGELOG](https://github.com/mozilla-releng/releasewarrior-2.0/wiki/ReleaseDuty-Cycle-CHANGELOG/)
+- we track all major changes in this newly added CHANGELOG
 
 ### Changed
 - old release promotion based on [releasetasks](https://github.com/mozilla/releasetasks/) is dead. Everything is in-tree scheduled now. Changes are riding the trains. More on this [here](https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Overview-TC) and [here](https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks-TC)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,39 @@
+Every time a new releaseduty cycle begings, new RelEng people are (re)ramping up. To ease the transition, we're keeping this CHANGELOG that should trace all the tools/productivity/infrastructure changes. This include high-level changes and should come into compliance with the rest of the documentation. 
+
+This page best serves the people that have previously been into the releaseduty cycle. Starting from the baseline, people coming back after `N` cycles can ramp up incrementally with the latest changes.
+
+_**As releaseduty squirrels are the ones with the best context when it comes to releases, they are the ones to edit this page and amend it accordingly. Keep in mind that changes should be in compliance with the other pieces of documentation.**_
+
+## During 59.0 >= 2018-01-24
+
+### Added 
+- We track all major changes in this newly added [CHANGELOG](https://github.com/mozilla-releng/releasewarrior-2.0/wiki/ReleaseDuty-Cycle-CHANGELOG/)
+
+### Changed 
+- old release promotion based on [releasetasks](https://github.com/mozilla/releasetasks/) is dead. Everything is in-tree scheduled now. Changes are riding the trains. More on this [here](https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Overview-TC) and [here](https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks-TC)
+
+## During 58.0 >= 2017-11-15
+
+### Added 
+- The use of the new [releasewarrior](https://github.com/mozilla-releng/releasewarrior-2.0)
+
+### Changed
+- old how-tos are now gathered under one roof in releasewarrior-2.0/old-howtos[releasewarrior-2.0/old-how-tos](https://github.com/mozilla-releng/releasewarrior-2.0/tree/master/old-how-tos) but they are gradually being migrated to the [wiki](https://github.com/mozilla-releng/releasewarrior-2.0/wiki) which becomes the single source of truth
+- authentication method for [taskcluster-cli](https://github.com/taskcluster/taskcluster-cli#installation) changed. If you are upgrading from an older version of taskcluster-cli, you may have to remove the `${HOME}/.config/taskcluster.yml` file to work with the new authentication method.
+
+### Removed
+- dropped support for old [releasewarrior](https://github.com/mozilla/releasewarrior/)
+- dropped the need for QE signoffs in Balrog  
+
+## During 57.0 >= 2017-09-27
+
+### Added 
+- A merge day instance has been added to ease the handover during mergedays but also for speed and reliability. More on this [here](https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Merge-Duty). When connecting  to the merge day instance, keep in mind to ensure its environment is clean and ready for use
+- simplified documentation for mid-betas and release checklists. If not already, duplicate an existing sheet in this [google docs checklist](https://docs.google.com/spreadsheets/d/1hhYtmyLc0GEk_NaK45KjRvhyppw7s7YSpC9xudaQZgo/edit#gid=1158959417) and clear out the status that was carried over from the previous release.
+
+### Changed
+- Mergeduty dates shifted. We now merge `beta` to `release` and `cetral` to `beta` in the same day, keeping a relbranch for `beta` and hold `central` from version bump until before the release. 
+- because of 57 and the aforementioned mergeduty change, *the exception becomes rule* so that for each new beta cycle X, we have X.0b1 and X.b2 **just** for `Devedition`, while `Firefox` starts at X.b3
+
+### Removed
+- dropped support for [tctalker](https://github.com/mozilla/tctalker) and solely rely on [taskcluster-cli](https://github.com/taskcluster/taskcluster-cli). More on its installation [here](https://github.com/taskcluster/taskcluster-cli#installation)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,4 @@
-Every time a new releaseduty cycle begings, new RelEng people are (re)ramping up. To ease the transition, we're keeping this CHANGELOG that should trace all the tools/productivity/infrastructure changes. This include high-level changes and should come into compliance with the rest of the documentation. 
+Every time a new releaseduty cycle begings, new RelEng people are (re)ramping up. To ease the transition, we're keeping this CHANGELOG that should trace all the tools/productivity/infrastructure changes. This include high-level changes and should come into compliance with the rest of the documentation.
 
 This page best serves the people that have previously been into the releaseduty cycle. Starting from the baseline, people coming back after `N` cycles can ramp up incrementally with the latest changes.
 
@@ -6,16 +6,17 @@ _**As releaseduty squirrels are the ones with the best context when it comes to 
 
 ## During 59.0 >= 2018-01-24
 
-### Added 
-- We track all major changes in this newly added [CHANGELOG](https://github.com/mozilla-releng/releasewarrior-2.0/wiki/ReleaseDuty-Cycle-CHANGELOG/)
+### Added
+- we track all major changes in this newly added [CHANGELOG](https://github.com/mozilla-releng/releasewarrior-2.0/wiki/ReleaseDuty-Cycle-CHANGELOG/)
 
-### Changed 
+### Changed
 - old release promotion based on [releasetasks](https://github.com/mozilla/releasetasks/) is dead. Everything is in-tree scheduled now. Changes are riding the trains. More on this [here](https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Overview-TC) and [here](https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks-TC)
+- all releaseduty related documentation has been moved out of the wiki under [warrior's](https://github.com/mozilla-releng/releasewarrior-2.0) `docs` subfolder.
 
 ## During 58.0 >= 2017-11-15
 
-### Added 
-- The use of the new [releasewarrior](https://github.com/mozilla-releng/releasewarrior-2.0)
+### Added
+- the use of the new [releasewarrior](https://github.com/mozilla-releng/releasewarrior-2.0)
 
 ### Changed
 - old how-tos are now gathered under one roof in releasewarrior-2.0/old-howtos[releasewarrior-2.0/old-how-tos](https://github.com/mozilla-releng/releasewarrior-2.0/tree/master/old-how-tos) but they are gradually being migrated to the [wiki](https://github.com/mozilla-releng/releasewarrior-2.0/wiki) which becomes the single source of truth
@@ -23,16 +24,16 @@ _**As releaseduty squirrels are the ones with the best context when it comes to 
 
 ### Removed
 - dropped support for old [releasewarrior](https://github.com/mozilla/releasewarrior/)
-- dropped the need for QE signoffs in Balrog  
+- dropped the need for QE signoffs in Balrog
 
 ## During 57.0 >= 2017-09-27
 
-### Added 
-- A merge day instance has been added to ease the handover during mergedays but also for speed and reliability. More on this [here](https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Merge-Duty). When connecting  to the merge day instance, keep in mind to ensure its environment is clean and ready for use
+### Added
+- a merge day instance has been added to ease the handover during mergedays but also for speed and reliability. More on this [here](https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Merge-Duty). When connecting  to the merge day instance, keep in mind to ensure its environment is clean and ready for use
 - simplified documentation for mid-betas and release checklists. If not already, duplicate an existing sheet in this [google docs checklist](https://docs.google.com/spreadsheets/d/1hhYtmyLc0GEk_NaK45KjRvhyppw7s7YSpC9xudaQZgo/edit#gid=1158959417) and clear out the status that was carried over from the previous release.
 
 ### Changed
-- Mergeduty dates shifted. We now merge `beta` to `release` and `cetral` to `beta` in the same day, keeping a relbranch for `beta` and hold `central` from version bump until before the release. 
+- mergeduty dates shifted. We now merge `beta` to `release` and `cetral` to `beta` in the same day, keeping a relbranch for `beta` and hold `central` from version bump until before the release.
 - because of 57 and the aforementioned mergeduty change, *the exception becomes rule* so that for each new beta cycle X, we have X.0b1 and X.b2 **just** for `Devedition`, while `Firefox` starts at X.b3
 
 ### Removed

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,32 @@
+
+# ReleaseWarrior and ReleaseDuty
+
+ReleaseDuty is a duty cycle where an engineer is responsible for operational
+tasks related to releasing new versions of Firefox. 
+
+ReleaseWarrior is a tool to help the on-duty engineers perform those tasks,
+and to keep track of release progress and issues.
+
+## Overview
+
+Two people are assigned to ReleaseDuty every six weeks, preferably in different timezones to extend
+available coverage.  There are specific days in a cycle when set tasks must be
+done, such as creating a beta or release candidate, and other unscheduled work
+that depends on issues that need fixing, and special requirements that specific
+release might have.
+
+# Release Duties
+
+* Performing operational tasks for incoming Nightly, DevEdition, Beta, ESR, Release Candidate and final releases
+* Merging repositories to create new beta, release candidates, releases and extended support releases.
+* Coordinating with other teams, such as Release Management, Quality Engineering, Sheriffs, and other developers
+* Fixing and improving the release automation, including both tools and processes
+* Maintaining a logbook of issues and progress using releasewarrior.
+* Arranging event post-mortems, if required.
+
+The individual accountable for a release is known as the 'release owner',
+and this is usually a specific member of Release Management.
+Details about release owners and people on release duty can be found at
+<https://wiki.mozilla.org/Release_Management/Release_owners>
+
+Known regular meetings are the Channel Meeting, every Tuesday and Thursday, and the ReleaseDuty standup on Mondays.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,27 @@
 
 # ReleaseWarrior and ReleaseDuty
 
-ReleaseDuty is a duty cycle where an engineer is responsible for operational
-tasks related to releasing new versions of Firefox. 
+_ReleaseDuty_ is a duty cycle where an engineer is responsible for operational
+and monitoring tasks related to releasing the new versions of Mozilla's products.
 
-ReleaseWarrior is a tool to help the on-duty engineers perform those tasks,
-and to keep track of release progress and issues.
+_ReleaseWarrior_ is a tool to help the on-duty engineers perform those tasks,
+and to keep track of release progress and issues. It is the single source of truth
+where the coordination happens among the releaseduty squirrels.
+
+## Table of contents
+
+This folder gathers all releaseduty documentation under one single umbrella. The structure is as follows:
+
+[Overview](#Overview)
+[Release Duties](#Release Duties)
+├── [CHANGELOG](#TODO) - to track large changes to the workflow and tools of releaseduty
+├── [balrog](#TODO) - to track all Balrog related information and understanding
+├── [day1](#TODO) - day1 documentation for all releng folks starting/resuming their releaseduty cycle
+├── [development](#TODO) - documentation for various related pieces that are still under development (e.g. tcmigration or Ship It v2. stuff)
+├── [mergeduty](#TODO) - single point of truth for all that matters during mergeduty processes
+├── [misc-operations](#TODO) - various other pieces of documentation that come into handy while releaseduty
+├── [release-promotion](#TODO) - to track the bread and butter of releaseduty for all products and platforms
+└── [signing](#TODO) - to track any related signing duties that releaseduty must perform occasionally
 
 ## Overview
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,16 +12,16 @@ where the coordination happens among the releaseduty squirrels.
 
 This folder gathers all releaseduty documentation under one single umbrella. The structure is as follows:
 
-[Overview](#Overview)
-[Release Duties](#Release Duties)
-[CHANGELOG](#TODO) - to track large changes to the workflow and tools of releaseduty
-[balrog](#TODO) - to track all Balrog related information and understanding
-[day1](#TODO) - day1 documentation for all releng folks starting/resuming their releaseduty cycle
-[development](#TODO) - documentation for various related pieces that are still under development (e.g. tcmigration or Ship It v2. stuff)
-[mergeduty](#TODO) - single point of truth for all that matters during mergeduty processes
-[misc-operations](#TODO) - various other pieces of documentation that come into handy while releaseduty
-[release-promotion](#TODO) - to track the bread and butter of releaseduty for all products and platforms
-[signing](#TODO) - to track any related signing duties that releaseduty must perform occasionally
+- [Overview](#Overview)
+- [Release Duties](#Release Duties)
+- [CHANGELOG](#TODO) - to track large changes to the workflow and tools of releaseduty
+- [balrog](#TODO) - to track all Balrog related information and understanding
+- [day1](#TODO) - day1 documentation for all releng folks starting/resuming their releaseduty cycle
+- [development](#TODO) - documentation for various related pieces that are still under development (e.g. tcmigration or Ship It v2. stuff)
+- [mergeduty](#TODO) - single point of truth for all that matters during mergeduty processes
+- [misc-operations](#TODO) - various other pieces of documentation that come into handy while releaseduty
+- [release-promotion](#TODO) - to track the bread and butter of releaseduty for all products and platforms
+- [signing](#TODO) - to track any related signing duties that releaseduty must perform occasionally
 
 ## Overview
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,8 +12,6 @@ where the coordination happens among the releaseduty squirrels.
 
 This folder gathers all releaseduty documentation under one single umbrella. The structure is as follows:
 
-- [Overview](#Overview)
-- [Release Duties](#Release Duties)
 - [CHANGELOG](#TODO) - to track large changes to the workflow and tools of releaseduty
 - [balrog](#TODO) - to track all Balrog related information and understanding
 - [day1](#TODO) - day1 documentation for all releng folks starting/resuming their releaseduty cycle

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,14 +14,14 @@ This folder gathers all releaseduty documentation under one single umbrella. The
 
 [Overview](#Overview)
 [Release Duties](#Release Duties)
-├── [CHANGELOG](#TODO) - to track large changes to the workflow and tools of releaseduty
-├── [balrog](#TODO) - to track all Balrog related information and understanding
-├── [day1](#TODO) - day1 documentation for all releng folks starting/resuming their releaseduty cycle
-├── [development](#TODO) - documentation for various related pieces that are still under development (e.g. tcmigration or Ship It v2. stuff)
-├── [mergeduty](#TODO) - single point of truth for all that matters during mergeduty processes
-├── [misc-operations](#TODO) - various other pieces of documentation that come into handy while releaseduty
-├── [release-promotion](#TODO) - to track the bread and butter of releaseduty for all products and platforms
-└── [signing](#TODO) - to track any related signing duties that releaseduty must perform occasionally
+[CHANGELOG](#TODO) - to track large changes to the workflow and tools of releaseduty
+[balrog](#TODO) - to track all Balrog related information and understanding
+[day1](#TODO) - day1 documentation for all releng folks starting/resuming their releaseduty cycle
+[development](#TODO) - documentation for various related pieces that are still under development (e.g. tcmigration or Ship It v2. stuff)
+[mergeduty](#TODO) - single point of truth for all that matters during mergeduty processes
+[misc-operations](#TODO) - various other pieces of documentation that come into handy while releaseduty
+[release-promotion](#TODO) - to track the bread and butter of releaseduty for all products and platforms
+[signing](#TODO) - to track any related signing duties that releaseduty must perform occasionally
 
 ## Overview
 

--- a/docs/balrog/Balrog-and-Scheduled-Changes.md
+++ b/docs/balrog/Balrog-and-Scheduled-Changes.md
@@ -1,0 +1,27 @@
+Balrog can let you schedule changes in advance through its [Scheduled Changes UI](https://aus4-admin.mozilla.org/rules/scheduled_changes)
+
+## Responsibilities
+
+### RelEng
+
+RelEng is responsible for reviewing the scheduled change to ensure that the mechanics are correct. Most notably, the mapping, fallbackMapping, and backgroundRate need to be verified.
+
+### RelMan
+
+RelMan is responsible for reviewing the scheduled change to ensure that the shipping time is correct and to authorize that the release may be shipped. If circumstances change (eg, we discover a bug we're not willing to ship) after they sign off, they must revoke their signoff in Balrog.
+
+## Example
+
+After the Scheduled Change has been created, the Balrog UI will look something like:
+![scheduled change without signoffs](/how-tos/only_scheduled.png?raw=true)
+
+When RelEng reviews it, they will look at the Mapping, Fallback Mapping, and Background Rate (circled above). If everything looks good, they will click on the "Signoff as..." button and be presented with a dialog like:
+![signoff modal dialog](/how-tos/signoff_dialog.png?raw=true)
+
+After they make their Signoff, the primary UI will reflect that:
+![scheduled change with one signoff](/how-tos/one_signoff.png?raw=true)
+
+RelMan and QE will go through a similar process. Once they make their Signoffs the primary UI will reflect that as well:
+![scheduled change with two signoffs](/how-tos/all_signoffs.png?raw=true)
+
+Now that the Signoff requirements have been met, the Scheduled Change will be enacted at the prescribed time.

--- a/docs/day1/Go-To-Build.md
+++ b/docs/day1/Go-To-Build.md
@@ -1,0 +1,84 @@
+
+## Background
+
+When a new release goes to build, we need to track its progress in releasewarrior to ensure the right things happen at the right time. Following these instructions adds a release to releasewarrior.
+
+## Prerequisites
+- [releasewarrior-2.0](https://github.com/mozilla-releng/releasewarrior-2.0#installing) installed and working, with write access to that repository.
+
+
+## When to perform these steps
+
+The release-signoff mailing list will receive a message alerting us to a new build being created in ship-it. Here is an example email:
+
+    
+    subject: [desktop] Build of Firefox-58.0b5-build1
+
+    A new build has been submitted through ship-it:
+
+    Commit: https://hg.mozilla.org/releases/mozilla-beta/rev/f155e109bb419696beb422b5afbfd7299b2b2500
+    Task group: https://tools.taskcluster.net/push-inspector/#/C8umMF6qSKy3X1tntYk1pA
+    Locales: https://ship-it.mozilla.org/releases/Firefox-58.0b5-build1/l10n (requires VPN access)
+
+    Created by release manager @ mozilla.com
+    Started by release manager @ mozilla.com
+
+    Comparing Mercurial tag FIREFOX_58_0b4_RELEASE to FIREFOX_58_0b5_RELEASE:
+    Bugs since previous changeset: https://mzl.la/2j8Tbfe
+    Full Mercurial changelog: https://hg.mozilla.org/releases/mozilla-beta/pushloghtml?
+    fromchange=FIREFOX_58_0b4_RELEASE&tochange=f155e109bb419696beb422b5afbfd7299b2b2500&full=1
+
+## What to do
+
+1. Get the product, version and task group ID from the email. In the example above these are:
+    ```sh
+    product=firefox
+    version=58.0b5 # Remove any -build suffix.
+    graphid="C8umMF6qSKy3X1tntYk1pA"
+    ```
+1. Ensure releasewarrior is working by typing: `release status`. You may need to go to the `releasewarrior-data` directory and run `git pull`
+1. If `release status` does not show the release in the 'UPCOMING RELEASES' section, you will need to track it:
+    ```sh
+    release track ${product} ${version}
+    ```
+1. Create a new build in releasewarrior:
+    ```sh
+    release newbuild --graphid ${graphid} ${product} ${version} 
+    ```
+1. Change to the `releasewarrior-data` repository and push changes
+    ```sh
+    cd ../releasewarrior-data # Assuming both are cloned into the same parent
+    git push
+    ```
+1. No email reply is necessary when creating a new build.
+
+## Example of success
+
+```
+$ release newbuild --graphid C8umMF6qSKy3X1tntYk1pA firefox 58.0b5
+INFO: ensuring releasewarrior repo is up to date and in sync with origin
+INFO: generating wiki from template and config
+INFO: writing to data file: /Users/sfraser/github/mozilla-releng/releasewarrior-data/inflight/firefox/firefox-beta-58.0b5.json
+INFO: writing to wiki file: /Users/sfraser/github/mozilla-releng/releasewarrior-data/inflight/firefox/firefox-beta-58.0b5.md
+INFO: writing to corsica file: /Users/sfraser/github/mozilla-releng/releasewarrior-data/index.html
+INFO: committing changes with message: firefox 58.0b5 - new buildnum started. 
+```
+
+## Troubleshooting
+
+Symptom:
+```
+$ release newbuild --graphid d4EXAosbTPuxWoSHOGkdXQ devedition 58.0b5 
+CRITICAL: data file was expected to exist in either upcoming or inflight path: /Users/sfraser/github/mozilla-releng/releasewarrior-data/upcoming/devedition/devedition-devedition-58.0b5.json, /Users/sfraser/github/mozilla-releng/releasewarrior-data/inflight/devedition/devedition-devedition-58.0b5.json
+INFO: ensuring releasewarrior repo is up to date and in sync with origin
+```
+Cause:
+You have not tracked this release. Track it with `release track ${product} ${version}` before creating a new build for it.
+
+Symptom:
+```
+$ release track devedition 58.0b5 
+CRITICAL: data file already exists in one of the following paths: /Users/sfraser/github/mozilla-releng/releasewarrior-data/upcoming/devedition/devedition-devedition-58.0b5.json, /Users/sfraser/github/mozilla-releng/releasewarrior-data/inflight/devedition/devedition-devedition-58.0b5.json
+INFO: ensuring releasewarrior repo is up to date and in sync with origin
+```
+Cause: You have already tracked this release. Continue with the next step.

--- a/docs/day1/ReleaseDuty-Day-1-Checklist-and-FAQ.md
+++ b/docs/day1/ReleaseDuty-Day-1-Checklist-and-FAQ.md
@@ -1,0 +1,195 @@
+If you're reading this page it means that you're ramping up as an official releaseduty squirrel within Mozilla RelEng, so please allow us to give you a warm welcome!
+
+Releaseduty is a designated pass-the-token role that we assign every 6 weeks to members of the team. The role mainly involves handling all the coordination and communication with other [teams](#Teams) as well as doing all the operational tasks to make sure the release workflow is as smooth as possible.
+
+While this role can get quite disruptive, we prefer this approach of assigning the responsibility to a small set of people who will own all the tasks, while we shield the others in Release Engineering from interruptions.
+
+Being ReleaseDuty means a couple of things:
+- Communication and coordination with other teams
+- Handle all incoming releases
+- Fix and debug any potential errors in the automation
+- Develop and improve the Release Automation process and tools
+
+## Communication
+
+Most of the steps and milestones of a release will be sent by email. The rest of the communication takes place in a few IRC channels.
+
+The automation status is sent by email, and very spammy.
+
+Meetings are usually conducted using [Vidyo](https://mana.mozilla.org/wiki/display/SD/Vidyo)
+
+### IRC Channels
+
+Join Mozilla's IRC network using either the [public documentation](https://wiki.mozilla.org/IRC) or if you have an LDAP account, you can also use [IRCCloud](https://mana.mozilla.org/wiki/display/SD/IRCCloud+Account+Setup)
+
+You ought to be present and pay attention to conversations happening in:
+- **_#releaseduty_** (main RelEng dedicated communication channel for releaseduty)
+- **_#release-drivers_** (where QE and RelMan usually coordinate)
+- **_#releng_** (public RelEng channel where many non-releaseduty topics are also discussed)
+- **_#relman_** (optional - about to be retired soon, where RelMan hangs out around usually)
+- **_#tbdrivers_** (where TB drivers discuss Thunderbird releases)
+
+Older channels, which are not currently required, but listed here for information:
+- **_#release-notifications_** (very spammy channel where all release automation notifications are being sent)
+- **_#release-notifications-dev_** (spammy channel where all staging releases notifications are being sent)
+
+### Email 
+
+As ReleaseDuty you need to *subscribe* to certain mailing lists.
+
+- All types of sign-offs and approvals should go to [release signoff mailing list](https://mail.mozilla.org/listinfo/release-signoff)
+- All releng automation emails should go to [release-automation-notifications](https://groups.google.com/a/mozilla.com/forum/?hl=en#!forum/release-automation-notifications)
+- All discussion topics should go to [release drivers mailing list](https://mail.mozilla.org/listinfo/release-drivers)
+
+These other mailing lists will likely have useful discussions and information:
+- [RelEng internal mailing list](release@mozilla.com)
+- [Thunderbird release drivers mailing list](https://mail.mozilla.org/listinfo/thunderbird-drivers)
+- [release-automation-notifications-thunderbird mailing list](https://mail.mozilla.org/listinfo/release-automation-notifications-thunderbird)
+- (optional) [release-automation-notifications-dev mailing list](https://groups.google.com/a/mozilla.com/forum/#!forum/release-automation-notifications-dev)
+
+### Meetings and Calendars
+
+Regular meetings are a vital part of making sure all the teams are kept informed and consulted during the release process. To view those meetings in your calendar you need to subscribe/be added to the following calendars:
+- [Public - Release Engineering](https://calendar.google.com/calendar/embed?src=mozilla.com_2d32343333353036312d393737%40resource.calendar.google.com) (so that you attend the weekly post-mortem meeting)
+- [Releases Scheduling](https://calendar.google.com/calendar/embed?src=mozilla.com_dbq84anr9i8tcnmhabatstv5co@group.calendar.google.com) (so that you can attend the Tuesday/Thursday channel meetings. You can add it following RelMan's [docs](https://wiki.mozilla.org/Release_Management#Calendar_Updating))
+-- If their instructions don't work, try to the "Add to Google Calendar" button at the [web version of the calendar](https://calendar.google.com/calendar/embed?src=mozilla.com_dbq84anr9i8tcnmhabatstv5co@group.calendar.google.com).
+
+_**If you join a calendar and it's blank, you may need to delete it and get a calendar invitation from an existing subscriber**_
+
+### Documents
+
+There's a simplified documentation for mid-betas and release checklists to ease the steps needed to happen. If not already, duplicate an existing sheet in this [google docs checklist](https://docs.google.com/spreadsheets/d/1hhYtmyLc0GEk_NaK45KjRvhyppw7s7YSpC9xudaQZgo/edit#gid=1158959417) and clear out the status that was carried over from the previous release.
+
+## Repository and Tool Access
+
+Several tools for managing releases are protected or private.
+In order to do your job,  you need to be granted access to a bare minimum:
+
+- Access to the [VPN](https://mana.mozilla.org/wiki/display/SD/VPN)
+- A [Bugzilla](https://bugzilla.mozilla.org/) account
+- Write access to [releasewarrior-2.0](https://github.com/mozilla-releng/releasewarrior-2.0/) and [releasewarrior-data](https://github.com/mozilla-releng/releasewarrior-data/) repo
+- Read/write access to [Balrog](https://aus4-admin.mozilla.org/)
+- Read access to [Ship-it](https://ship-it.mozilla.org/)
+- SSH access to `buildbot-master85.bb.releng.scl3.mozilla.com`.
+
+There are a few more other places where access is needed (such as [bouncer](https://bounceradmin.mozilla.com/admin/), etc) but we're trying to keep those access-list short so addings can be done in time depending on necessities.
+
+## Installing Tools
+
+### ReleaseWarrior
+
+This is the wiki for ReleaseWarrior! It helps us keep track of the releases in flight and generating the post-mortem.
+
+See [the releasewarrior repo](https://github.com/mozilla-releng/releasewarrior-2.0/#installing) for instructions on installation and configuration
+
+The `release` command should now be available inside your virtual environment. Other wiki pages will explain how to use it.
+
+### taskcluster
+
+Release tasks are usually run through [Taskcluster](https://docs.taskcluster.net/), which has a useful [Command-line interface](https://github.com/taskcluster/taskcluster-cli)
+
+- Download an appropriate binary from <https://github.com/taskcluster/taskcluster-cli#installation>
+- Copy the binary somewhere useful, such as somewhere in your [`$PATH`](http://www.linfo.org/path_env_var.html)
+- Make it executable, if using Mac or Linux: `chmod a+x /path/to/taskcluster`
+- `taskcluster signin` - this will open a browser window and allow you to get temporary client credentials. By default this is valid for 24 hours. **The command will display two `export` commands you must copy/paste into your shell**
+- Familiarise yourself with the subcommands, starting with `taskcluster help`
+
+### Firefox bookmarks
+
+These bookmarklets should help you view tasks and taskgroups in Firefox.
+
+* Go to Bookmarks -> Show All Bookmarks
+* Gear symbol -> New Bookmark
+* Name: `task inspector` Location: [https://tools.taskcluster.net/tasks/%s](https://tools.taskcluster.net/tasks/%s) ; Keyword: `task`
+* Name: `taskgroup inspector` Location: [https://tools.taskcluster.net/groups/%s](https://tools.taskcluster.net/groups/%s) ; Keyword: `taskgroup`
+* Name: `stop` Location: `javascript:stop();`
+  * This can be used to stop further loading in the Task Group Inspector. It shouldn't be used when actively monitoring (ie: watching for failures), but it can greatly speed things up if you're using it for other reasons. Be sure to wait for the initial tasks to load before you use it.
+
+Now if you go to your URL bar, you can type `task TASKID` or `taskgroup TASKGROUPID` and you'll go to that task or taskgroup in the inspector.
+
+## After ReleaseDuty
+
+After your tour of releaseduty, it's customary to spend 1-2 weeks fixing release automation issues. Check the  [Release Automation Improvements trello board](https://trello.com/b/BqnBcfXX/release-automation-improvements) trello board for ideas of what to work on and to add new items as you discover them.
+
+## Miscellaneous
+
+- Bugzilla issues regarding specific releases/WNP are filed under [Release Engineering:Releases](https://bugzilla.mozilla.org/enter_bug.cgi?product=Release%20Engineering&component=Releases)
+- Issues regarding automation are filed under [Release Engineering:Release Automation](https://bugzilla.mozilla.org/enter_bug.cgi?product=Release%20Engineering&component=Release%20Automation)
+- Historically, we've used this [etherpad](https://public.etherpad-mozilla.org/p/releaseduty_handoff) to handoff any information from one squirrely to another when cycle. It's optional but feel free to reuse this
+
+## Teams
+
+- [Release Engineering](https://wiki.mozilla.org/ReleaseEngineering) (Releng)
+- [Release Management](https://wiki.mozilla.org/Release_Management) (Relman)
+- [Quality Assurance](https://wiki.mozilla.org/QA) (QA / QE) and their [testing notes](https://quality.mozilla.org/)
+
+## Other useful resources
+
+- More on [Release Management](https://wiki.mozilla.org/Release_Management)
+
+
+## Glossary
+
+- WNP - The "What's New Page" can be set to appear after an upgrade, to tell end-users of any changes in the browser they should be aware of.
+- FF - Firefox
+- TB - Thunderbird
+- b1, b2, etc  - beta release 1, beta release 2, etc
+
+## FAQ
+
+1. *How does the Ship-it workflow function in terms of shipping a new release?*
+
+RelMan submits a new release from [here](https://ship-it.mozilla.org/), another RelMan reviews that and once it hits 'Ready' + 'Do eeaat' the release enters the 'Reviewed' section and waits to be run.
+Since there's a `release-runner.sh` script running in a loop on [bm81](https://hg.mozilla.org/build/puppet/file/default/manifests/moco-nodes.pp#l598), there's a max window of 60 seconds till the job gets its share, following which it enters the 'Running/Complete' table where we can observe its state.
+The "Reviewed" tab goes to "No pending release" yet again.
+
+2. *What does release-promotion refer to?*
+
+'Release promotion' is simply the idea that we take an already existing CI build from (e.g. beta) and promote that to being the build we release/ship to users. Prior to this approach, we had always rebuilt Firefox at the start of each new release.
+Long story short, release promotion entails taking an existing set of builds that have already been triggered and passed QA and “promoting” them to be used as a release candidate. More on promotion can be found on our wiki [here](https://wiki.mozilla.org/ReleaseEngineering/Release_build_promotion)
+
+3. *What is the train model?*
+
+Since 2012 Mozilla moved to a fixed-schedule release model, otherwise known as the Train Model, in which we released Firefox every six weeks to get features and updates to users faster and move at the speed of the Web. Hence, every six weeks the following merges take place:
+[mozilla-beta](http://hg.mozilla.org/releases/mozilla-beta/) => [mozilla-release](http://hg.mozilla.org/releases/mozilla-release/)
+[mozilla-central](http://hg.mozilla.org/mozilla-central/) => [mozilla-beta](http://hg.mozilla.org/releases/mozilla-beta/)
+
+We used to have an intermediate branch named 'aurora' in between central and beta but that was brought to end-of-life during April-May 2017. Instead, early beta releases are branded as 'DevEdition'.
+
+4. *What is a partner repack change for FF?*
+
+Partner repacks refer to 3rd party customized branded versions of Firefox that Mozilla is taking care of for some of its clients. With some exceptions, most of the partner reconfigs lie under private repositories.
+Mostly, the partner repacks don't need too much of RelEng interference as all bits are held under private git repos and are directly handled by the partnering companies
+
+5. *Is there calendar-based release scheduled for Thunderbird as for Firefox?*
+
+No. It's irregular. Conversations happen on #tbdrivers and TB mailing list and they trigger their release in Ship-it.
+
+6. *Why don't I see update_verify_beta for dot releases?*
+
+From time to time, a handful of issues precipitate a dot release. When that happens, its behavior slightly varies from a normal release. A normal release (e.g. 43.0, 44.0, etc) has its RC shipped to beta channel first before making it to the release channel - for testing purposes, update verify steps are taking place both ways, hence update_verify_release and update_verify_beta steps. Upon a successful testing phase we ship the RC on the beta channel and then on the release channel,
+following which we merge the code for the next release cycle so that the beta release bumps its version. In the lights of this logic, a dot release (e.g. 43.0.1 or 44.0.1) happens a certain amount of time after the official release.
+For that reason, a dot release can't be tested in beta channel as the at-that-moment beta version is greater than the dot release version, hence the updater would refuse to downgrade. Therefore, there is only one cycle of update_verify for dot releases (update_verify_release == update_verify in this case).
+
+
+7.  *How do I start the Fennec build after it has been submitted to ship it by Relman?*
+
+The Fennec build is not started automatically after it is submitted to ship-it as occurs with the desktop builds.  The Fennec build is usually submitted to ship-it by RelMan at the same time as desktop builds so you'll have to start it manually using the steps here [Fennec Release promotion](https://github.com/mozilla/releasewarrior/fennec-temp-relpro.md) After [bug 134765] (https://bugzilla.mozilla.org/show_bug.cgi?id=1347635) is resolved, the Fennec builds will be started automatically by ship-it.
+
+
+8.  *Is there explicit signoff from RelMan for DevEdition builds?*
+
+No, after b1, there isn't signoff from RelMan on DevEdition builds.  QA only verifies the DevEdition builds every two weeks. With the exception of b1, and assuming all the tasks complete as expected, the DevEdition builds should be shipped at the same time as we receive signoff for the corresponding desktop builds.
+
+
+9. *Can RelEng adjust the rate of the Firefox apk in the Google play store?*
+
+By default, the push apk task for Fennec sets a rate of 10% in the Google Play store for b1, 100% for other betas.  After b1, you will have land a patch on beta to change the rate to 100% on mozilla-beta.  See ( Mobile Firefox push to Play Store always re-sets the update rate to 10%)[https://bugzilla.mozilla.org/show_bug.cgi?id=1393207] for details. Relman is responsible for adjusting the rate as required. Releng folks don't have write access to the google store to change this value.
+
+10. *How should I inform the ReleaseDuty team of recent changes in automation that may impact an upcoming release?*
+
+You can mention it to the current ReleaseDuty folks in the #releaseduty channel. Please also add it to the upcoming release in the ../releases/FUTURE/ dir. See [future release support](../releases/FUTURE/README.md) for more details.
+
+11. *How do I coordinate with marketing on release day?*
+
+Join the #release-coordination channel on Mozilla Slack

--- a/docs/development/Maple-(tc-relpro-development---staging).md
+++ b/docs/development/Maple-(tc-relpro-development---staging).md
@@ -1,0 +1,171 @@
+Currently, maple is our taskcluster beta relpro migration area, and birch is our taskcluster RC relpro staging area.
+
+---
+# Current status
+
+## Trello
+
+The [Trello board](https://trello.com/b/EGWsGSXT/tc-migration-release-h1-2018) has the latest human tasks. As of Feb 8, we're working on removing buildbot and buildbot-bridge from releases.
+
+Please feel free to add tasks there if we're missing any!
+
+---
+
+## Dep vs release
+
+Right now, we're set up with release signing, until we remove that as a staging release requirement.
+
+---
+
+# how-to
+## Trigger relpro: promote
+
+Launch a new promotion graph using [ship-it dev](https://ship-it-dev.allizom.org/).
+
+1. Click "Ship a new release"
+1. Fennec, Devedition, or Firefox
+1. The version will be displayed [here](https://hg.mozilla.org/projects/maple/file/tip/browser/config/version_display.txt) -- `59.0b6` as of this writing.
+1. The branch is `projects/maple`
+1. Choose partials. It's probably easiest to copy prior art here; Aki is unfamiliar with what staging voodoo we use to choose the proper partials.
+1. Enter the maple revision... probably the latest from [here](https://hg.mozilla.org/projects/maple/summary)
+1. Click "Gimme a <product>"
+1. Click "View releases" -> "Submitted"
+1. Click "Ready" and "Do eet"
+1. The new relpro action should be on [treeherder](https://treeherder.mozilla.org/#/jobs?repo=maple). The name should be `promote_PRODUCT` or `promote_PRODUCT_rc` based on the version number.
+1. the taskId is on the lower left. Clicking on it will bring you to the log
+1. pasting the taskid into the url `https://tools.taskcluster.net/groups/TASKID` will bring you to the promotion graph. [These bookmarks](https://github.com/mozilla-releng/releasewarrior-2.0/wiki/ReleaseDuty-Day-1-Checklist-and-FAQ#firefox-bookmarks) will probably help a lot!
+
+## Trigger relpro: push and ship
+
+2018-02-08: The releaseduty push and ship docs may be more up to date at this point.
+
+The `ACTION_FLAVOR` should be one of [these actions](https://hg.mozilla.org/build/tools/file/default/buildfarm/release/trigger_action.py#l20)
+
+For a standard post-promote action (
+* generally everything but an RC `ship`,
+* the same revision used to build and promote is acceptable to push and ship with), run this:
+
+```bash
+# standard action after a promote. This will be a ship-without-a-push or a push.
+ssh buildbot-master83.bb.releng.scl3.mozilla.com
+sudo su - cltbld
+cd /builds/releaserunner3/
+source bin/activate
+# set the action task id to the taskId of the promotion relpro action
+PROMOTE_TASK_ID=M1QFL1R7RWCTReFLsRWmGw
+ACTION_FLAVOR=ship_fennec
+python tools/buildfarm/release/trigger_action.py --action-task-id $PROMOTE_TASK_ID --release-runner-config /builds/releaserunner3/release-runner.yml --action-flavor $ACTION_FLAVOR
+```
+
+For a standard post-promote action with some push or ship fixes in a newer revision (
+* generally every relpro flavor but an RC `ship`,
+* the revision wanted to push and ship with has some graph fixes that landed after the build and promote revision), run this:
+
+```bash
+# standard action on a newer revision after a promote.
+# This will be a ship-without-a-push or a push
+ssh buildbot-master83.bb.releng.scl3.mozilla.com
+sudo su - cltbld
+cd /builds/releaserunner3/
+source bin/activate
+# set the action task id to the taskId of the promotion relpro action
+PROMOTE_TASK_ID=M1QFL1R7RWCTReFLsRWmGw
+# use the decision task id *of the revision you want to use to push and ship with*
+DECISION_TASK_ID=Ov8k7qUoQG2PHCK5sRfzHw
+ACTION_FLAVOR=ship_fennec
+python tools/buildfarm/release/trigger_action.py --action-task-id $PROMOTE_TASK_ID --decision-task-id $DECISION_TASK_ID --release-runner-config /builds/releaserunner3/release-runner.yml --action-flavor $ACTION_FLAVOR
+```
+
+During RCs, we run `promote`, then `push`. To run `ship`, do the following:
+
+```bash
+# ship action, after having run both promote and push (RC behavior)
+ssh buildbot-master83.bb.releng.scl3.mozilla.com
+sudo su - cltbld
+cd /builds/releaserunner3/
+source bin/activate
+# set the action task id to the taskId of the push relpro action
+PUSH_TASK_ID=Xiz4JZ20SwijU7bXrbVOaw
+ACTION_FLAVOR=ship_firefox
+PROMOTE_TASK_ID=Iym4bESbSqyrA8M2TsxAiw
+# use the decision task id *of the revision you want to use to push and ship with*
+DECISION_TASK_ID=VXZvAlW5TMy078ekVwpl_A
+python tools/buildfarm/release/trigger_action.py --action-task-id $PUSH_TASK_ID --decision-task-id $DECISION_TASK_ID --previous-graph-ids $PROMOTE_TASK_ID --release-runner-config /builds/releaserunner3/release-runner.yml --action-flavor $ACTION_FLAVOR
+```
+
+The action should show up on treeherder; its taskId is the graph's group id as above.
+
+---
+## diff taskgraphs
+
+[`taskgraph-gen.py`](https://hg.mozilla.org/build/braindump/file/tip/taskcluster/taskgraph-diff/taskgraph-gen.py) lets you generate a bunch of graphs from a given revision. Once you generate graphs from 2 revisions, [`taskgraph-diff.py`](https://hg.mozilla.org/build/braindump/file/tip/taskcluster/taskgraph-diff/taskgraph-diff.py) lets you diff the two sets of graphs. This means you can diff the graphs generated from tip of central against the tip of maple, or from the tip of maple against maple + your patch, or whatever.
+
+e.g.
+
+```
+# First create virtualenv with dictdiffer and activate it
+# Then run:
+cd mozilla-unified
+hg up -r central
+../taskgraph-diff/taskgraph-gen.py --overwrite central
+hg up -r maple
+../taskgraph-diff/taskgraph-gen.py --overwrite maple
+../taskgraph-diff/taskgraph-diff.py central maple
+# diffs are in ../taskgraph-diff/json/maple/*.diff
+```
+
+In the above example, I've softlinked my `braindump/taskcluster/taskgraph-diff` directory to be a sibling of `mozilla-unified`.
+
+Caveats:
+
+- the diffs are kind of interesting to read. They're [dictdiffer](https://dictdiffer.readthedocs.io/en/latest) diffs [1]. Once you get the hang of them they work.
+- the params are checked in along with the scripts. These will break over time as people add and remove required parameters. Also, if we rename our `target_tasks_methods` we'll see breakage.
+
+We have a [`params_pre_buildnum`](https://hg.mozilla.org/build/braindump/file/tip/taskcluster/taskgraph-diff/params-pre-buildnum) directory we can use if we're generating task graphs from a pre-[bug 1415391](https://bugzilla.mozilla.org/show_bug.cgi?id=1415391) revision.
+
+---
+## debug release promotion action
+
+We can use `./mach taskgraph test-action-callback` to debug.
+
+I used
+
+```
+./mach taskgraph test-action-callback --task-group-id LR-xH1ViTTi2jrI-N1Mf2A --input /src/gecko/params/promote_fennec.yml -p /src/gecko/params/maple-promote-fennec.yml release_promotion_action > ../promote.json
+```
+
+`promote_fennec.yml`:
+
+(This is also the input I use in the action in treeherder)
+
+```yaml
+build_number: 1
+release_promotion_flavor: promote_fennec
+```
+
+For the parameters file, use the appropriate one from [braindump](https://hg.mozilla.org/build/braindump/file/tip/taskcluster/taskgraph-diff/params).
+
+I'm not 100% sure if it's important to use a promotion parameters file or an on-push one.
+
+---
+# hg / git - how Aki's muddling through
+
+I'm open to how we do this; I'm absolutely certain my method is not an ideal one.
+
+I like hg bookmarks for smaller projects, but for big ones like this one, I prefer git's rebase behavior to keep my patch queue sane. However, I haven't solved the push-to-hg part yet, so I'm working on maple, landing when I have a probably-good patch, debugging, and then rebasing my work on github.
+
+## Github
+- fork [gecko-dev](https://github.com/mozilla/gecko-dev/)
+- pull in [gecko-projects](https://github.com/mozilla/gecko-projects/) to your fork, by cloning, adding a remote, and fetching
+- after an m-c to maple merge, I pull gecko-dev's `master` branch and gecko-project's `maple` branch. Then I update to my `maple-staging` branch, and `git rebase -i master` and deal with any conflicts.
+- then I diff against `maple`. Sometimes it's easiest to export the revs from hg and `patch -p1 < patchfile` and `git commit`, then `git rebase -i master` to clean up the patches.
+
+I haven't tried cinnabar; it's based off a different set of changesets and doesn't follow maple. However, it would allow for pushing to hg.
+
+### git rebase
+
+## Hg
+
+Bookmarks are good for a single branch. I tend to clump all my unlanded patches into a single bookmark, `hg histedit` to edit the patches, and `hg rebase -b BOOKMARK -d maple` to rebase my bookmark against maple. Once the patches look good, I land and move over to git for my patch queue.
+
+### hg histedit + rebase

--- a/docs/misc-operations/Purging-the-Partials-Cache.md
+++ b/docs/misc-operations/Purging-the-Partials-Cache.md
@@ -1,0 +1,32 @@
+
+Partials generation uses an S3 bucket as a cache, to avoid computing the binary diffs of the same file once for each locale. However, if bad partials are generated this cache can end up with invalid entries. Here is how to remove the entire cache:
+
+```sh
+taskcluster signin
+```
+
+And follow the usual environment variable process.
+
+
+Set up the AWS temporary credentials, good for about an hour:
+```sh
+AUTH=$(taskcluster api auth awsS3Credentials read-write tc-gp-private-1d-us-east-1 releng/mbsdiff-cache/)
+AWS_ACCESS_KEY_ID=$(echo "${AUTH}" | jq -r '.credentials.accessKeyId')
+AWS_SECRET_ACCESS_KEY=$(echo "${AUTH}" | jq -r '.credentials.secretAccessKey')
+AWS_SESSION_TOKEN=$(echo "${AUTH}" | jq -r '.credentials.sessionToken')
+export AWS_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY
+export AWS_SESSION_TOKEN
+AUTH=
+```
+
+`aws` cli commands should now authenticate. 
+```sh
+aws s3 ls s3://tc-gp-private-1d-us-east-1/releng/mbsdiff-cache/ --recursive
+```
+
+
+Remove the files:
+```sh
+aws s3 rm s3://tc-gp-private-1d-us-east-1/releng/mbsdiff-cache/ --recursive
+```

--- a/docs/release-promotion/desktop/howto.md
+++ b/docs/release-promotion/desktop/howto.md
@@ -1,0 +1,165 @@
+## Requirements
+
+* taskcluster-cli installed
+* releasewarrior-2.0 installed
+* ssh access to `buildbot-master85.bb.releng.scl3.mozilla.com`
+
+## Push artifacts to releases directory
+
+### Background
+
+`releases`, `mirrors` and `CDN` are different terms for the same concept - the CDN from which shipped releases are served.
+
+In the new TC release promotion for Fx59+, pushing doesn't happen automatically in ship-it (yet). We can [address this](https://trello.com/c/vOP7fml4/282-update-releaserunner3-to-automatically-run-the-push-flavor-rather-than-promote-for-certain-release-types). Until then, all pushing will be manually triggered.
+
+### When - b2+ betas
+
+- For beta's we want to push to releases directories as soon as the builds are ready. Relng can trigger the `push` action as soon as the `promote` action task finishes (you do not need to wait for all of the tasks in the promote phase to complete). In the future we can have this [happen automatically](https://trello.com/c/vOP7fml4/282-update-releaserunner3-to-automatically-run-the-push-flavor-rather-than-promote-for-certain-release-types). (We are also in [discussion with relman](https://bugzilla.mozilla.org/show_bug.cgi?id=1433284) about future plans around this step)
+
+### When - releases
+
+* Release Management will send an email to the release-signoff mailing list, with a subject line of the form: `[desktop] Please push ${version} to ${channel}` 
+
+Examples:
+- `[desktop] Please push Firefox 57.0.1 (build#2) to the release-cdntest channel`
+- `[desktop] Please push Firefox 52.4.1esr to the esr-cdntest channel`
+
+This subject is free-text and may not always be the same format, but will have the same information in. You shouldn't expect to see these emails for `devedition` or `beta` as they update the releases directory automatically.
+
+Note: If they do not explicitly ask for `release-cdntest` it is okay to assume it is included. Please mention its inclusion in the reply, and ask for explicit channel names next time.
+
+* The build should all be green - watch for failures in the update verify tests, especially.
+
+### How
+
+* Find the `hg revision` of the release in [Ship It](http://ship-it.mozilla.org/), and copy it.
+
+* Run get_graphids.py from releasewarrior-2.0's scripts directory.
+
+```sh
+export REV=.. # Revision from above
+python ./scripts/get_graphids.py --output export --revision ${REV}
+```
+
+* For now, we have to ssh to bm85 to generate the push graph.
+
+```
+ssh buildbot-master85.bb.releng.scl3.mozilla.com
+sudo su - cltbld
+cd /builds/releaserunner3/
+source bin/activate
+# paste the export line from above, you should have found at least
+# a promote taskid.
+#   export DECISION_TASK_ID=...
+#   export PROMOTE_TASK_ID=...
+ACTION_FLAVOR=push_firefox  # For devedition, use push_devedition
+python tools/buildfarm/release/trigger_action.py \
+    ${PROMOTE_TASK_ID+--action-task-id ${PROMOTE_TASK_ID}} \
+    --release-runner-config /builds/releaserunner3/release-runner.yml \
+    --action-flavor ${ACTION_FLAVOR}
+# Unset ACTION_FLAVOR to minimize the possibility of rerunning with different graph ids
+unset ACTION_FLAVOR
+# Unset the other variables as well
+unset DECISION_TASK_ID
+unset PROMOTE_TASK_ID
+unset PUSH_TASK_ID
+# This will output the task definition and ask if you want to proceed.
+```
+  * The `taskId` of the action task will be the `taskGroupId` of the next graph.
+
+* Update releasewarrior:
+    ```sh
+    release task ${product} ${version} --resolve publish
+    cd ../releasewarrior-data && git push
+    ```
+
+## Ship the release
+
+### Background
+
+The `ship` phase should be triggered when the release is signed off. It runs the `update bouncer aliases`, `mark as shipped`, and `bump version` tasks.
+
+### When
+
+An email will arrive to the release-signoff mailing list asking for a release to be pushed to the appropriate channel, such as 'release' for major releases, 'beta' for betas, and so on.
+
+Examples
+- `[desktop] Please push Firefox 58.0b5 to beta and DevEdition to aurora`
+- `[desktop] Please push Firefox 57.0 (build#4) to the release channel (25%)`
+
+### How
+
+* Find the `hg revision` of the release in [Ship It](http://ship-it.mozilla.org/), and copy it.
+
+* Run get_graphids.py from releasewarrior-2.0's scripts directory.
+
+```sh
+export REV=.. # Revision from above
+python ./scripts/get_graphids.py --output export --revision ${REV}
+```
+
+* Then:
+
+```bash
+# ship action, after having run both promote and push (RC behavior)
+ssh buildbot-master85.bb.releng.scl3.mozilla.com
+sudo su - cltbld
+cd /builds/releaserunner3/
+source bin/activate
+# paste the export line from above, you should have found a
+# decision taskid, and a promote taskid, and a push taskid.
+#   export DECISION_TASK_ID=...
+#   export PROMOTE_TASK_ID=...
+#   export PUSH_TASK_ID=...
+ACTION_FLAVOR=ship_firefox  # or ship_devedition
+python tools/buildfarm/release/trigger_action.py \
+    ${PUSH_TASK_ID+--action-task-id ${PUSH_TASK_ID}} \
+    ${DECISION_TASK_ID+--decision-task-id ${DECISION_TASK_ID}} \
+    ${PROMOTE_TASK_ID+--previous-graph-ids ${PROMOTE_TASK_ID}} \
+    --release-runner-config /builds/releaserunner3/release-runner.yml \
+    --action-flavor ${ACTION_FLAVOR}
+# Unset ACTION_FLAVOR to minimize the possibility of rerunning with different graph ids
+unset ACTION_FLAVOR
+# Unset the other variables as well
+unset DECISION_TASK_ID
+unset PROMOTE_TASK_ID
+unset PUSH_TASK_ID
+# This will output the task definition and ask if you want to proceed.
+```
+  * The `taskId` of the action task will be the `taskGroupId` of the next graph.
+
+* Announce to release-signoff that the release is live
+* Update releasewarrior:
+    ```sh
+    release task ${product} ${version} --resolve publish
+    cd ../releasewarrior-data && git push
+    ```
+
+## Obtain sign-offs for changes
+
+### Background
+
+To guard against bad actors and compromised credentials we require that any changes to primary release channels (beta, release, ESR) in Balrog are signed off by at least two people.
+
+### When
+
+After the scheduled change has been created by the "updates" task, and prior to the desired release publish time
+
+### How
+
+* In context of the other rules, eg
+    * Firefox release: <https://aus4-admin.mozilla.org/rules?product=Firefox&channel=release>
+    * Firefox beta: <https://aus4-admin.mozilla.org/rules?product=Firefox&channel=beta>
+    * DevEdition: <https://aus4-admin.mozilla.org/rules?product=Firefox&channel=aurora>
+* Or using the Balrog Scheduled Changes UI: <https://aus4-admin.mozilla.org/rules/scheduled_changes>
+
+Update releasewarrior:
+```sh
+release task ${product} ${version} --resolve signoff
+cd ../releasewarrior-data && git push
+```
+
+Further details and examples can be found on the [[Balrog page|Balrog and Scheduled Changes]]
+
+If this is a Release (not a beta, devedition or RC), then schedule an update in Balrog to change the background rate of the rule to 0% the next day.
+* Go to Balrog and "Schedule an Update" for the "Firefox: release" rule that changes "backgroundRate" to 0 at 9am Pacific the following day. All other fields should remain the same.

--- a/docs/release-promotion/desktop/howto_58cycle_and_52esr_only.md
+++ b/docs/release-promotion/desktop/howto_58cycle_and_52esr_only.md
@@ -1,0 +1,121 @@
+## Requirements
+
+* taskcluster-cli installed
+* releasewarrior-2.0 installed
+
+## Push artifacts to releases directory
+
+### Background
+
+`releases`, `mirrors` and `CDN` are different terms for the same concept - the CDN from which published releases are served.
+
+### When
+
+* Release Management will send an email to the release-signoff mailing list, with a subject line of the form: `[desktop] Please push ${version} to ${channel}` 
+
+Examples:
+- `[desktop] Please push Firefox 57.0.1 (build#2) to the release-cdntest channel`
+- `[desktop] Please push Firefox 52.4.1esr to the esr-cdntest channel`
+
+This subject is free-text and may not always be the same format, but will have the same information in. You shouldn't expect to see these emails for `devedition` or `beta` as they update the releases directory automatically.
+
+Note: If they do not explicitly ask for `release-cdntest` it is okay to assume it is included. Please mention its inclusion in the reply, and ask for explicit channel names next time.
+
+* The build should all be green - watch for failures in the update verify tests, especially.
+
+### How - Plan A
+
+* Check the `release` command for the link to the task graph. 
+* There should be a pending task with "push to releases human decision task" in the name
+* Find the TaskID for this task, and resolve it:
+    ```sh
+    taskcluster task complete "${TASKID}"
+    ```
+* Update releasewarrior:
+    ```sh
+    release task ${product} ${version} --resolve mirrors
+    cd ../releasewarrior-data && git push
+    ```
+If there is no "push to releases task" pending, check for it failing. These tasks have a deadline of **4 days** and so can expire if testing takes longer than that. If it has expired, we must start a new task graph to do these steps. Follow Plan B.
+
+### How - Plan B
+
+To create the second graph:
+
+1. Get a TaskID from any task in graph 1. Yes, any task. This will be used by graph 2 for obtaining the release version, branch, etc.
+2. Call releasetasks_graph_gen.py:
+```bash
+ssh `whoami`@buildbot-master85.bb.releng.scl3.mozilla.com  # host we release-runner and you generate/submit new release promotion graphs
+sudo su - cltbld
+TASK_TASKID_FROM_GRAPH1={insert a taskid from any task in graph 1}
+
+# IF a release candidate
+BRANCH_CONFIG=prod_mozilla-release_firefox_rc_graph_2.yml
+# IF an ESR
+BRANCH_CONFIG=prod_mozilla-esr52_firefox_rc_graph_2.yml
+# No such config file for releases.
+
+cd /home/cltbld/releasetasks/
+git pull origin master  # make sure we are up to date. note: make sure this is on master and clean first
+cd /builds/releaserunner/tools/buildfarm/release/
+hg pull -u # make sure we are up to date. note: make sure this is on default and clean first
+source /builds/releaserunner/bin/activate
+
+# call releasetasks_graph_gen.py with --dry-run and sanity check the graph output that would be submitted
+python releasetasks_graph_gen.py --release-runner-config=../../../release-runner.yml --branch-and-product-config="/home/cltbld/releasetasks/releasetasks/release_configs/${BRANCH_CONFIG}" --common-task-id=$TASK_TASKID_FROM_GRAPH1 --dry-run
+
+# call releasetasks_graph_gen.py for reals which will submit the graph to Taskcluster
+python releasetasks_graph_gen.py --release-runner-config=../../../release-runner.yml --branch-and-product-config="/home/cltbld/releasetasks/releasetasks/release_configs/${BRANCH_CONFIG}" --common-task-id=$TASK_TASKID_FROM_GRAPH1
+```
+* Update releasewarrior as shown in Plan A
+
+## Publish the release
+
+### Background
+
+The `publish release human decision task` should be triggered after the release has been published in Balrog. It triggers the `update bouncer aliases`, `mark as shipped`, and `bump version` tasks.
+
+### When
+
+An email will arrive to the release-signoff mailing list asking for a release to be pushed to the appropriate channel, such as 'release' for major releases, 'beta' for betas, and so on.
+
+Examples
+- `[desktop] Please push Firefox 58.0b5 to beta and DevEdition to aurora`
+- `[desktop] Please push Firefox 57.0 (build#4) to the release channel (25%)`
+
+### How
+
+* Go to the task graph and find taskId of `publish release human decision task`
+* Resolve the "publish release human decision" task:
+    `taskcluster task complete <taskId>`
+* Announce to release-signoff that the release is live
+* Update releasewarrior:
+    ```sh
+    release task ${product} ${version} --resolve publish
+    cd ../releasewarrior-data && git push
+    ```
+
+## Obtain sign-offs for changes
+
+### Background
+
+To guard against bad actors and compromised credentials we require that any changes to primary release channels (beta, release, ESR) in Balrog are signed off by at least two people.
+
+### When
+
+After the scheduled change has been created by the "updates" task, and prior to the desired release publish time
+
+### How
+
+Using the Balrog Scheduled Changes UI: <https://aus4-admin.mozilla.org/rules/scheduled_changes>
+
+Update releasewarrior:
+```sh
+release task ${product} ${version} --resolve signoff
+cd ../releasewarrior-data && git push
+```
+
+Further details and examples can be found on the [[Balrog page|Balrog and Scheduled Changes]]
+
+If this is a Release (not a beta, devedition or RC), then schedule an update in Balrog to change the background rate of the rule to 0% the next day.
+* Go to Balrog and "Schedule an Update" for the "Firefox: release" rule that changes "backgroundRate" to 0 at 9am Pacific the following day. All other fields should remain the same.

--- a/docs/release-promotion/desktop/overview.md
+++ b/docs/release-promotion/desktop/overview.md
@@ -1,0 +1,22 @@
+
+
+# Requirements
+
+* All steps followed in the [[ReleaseDuty Day 1 Checklist|ReleaseDuty Day 1 Checklist and FAQ]]
+* Ability to run the `release` command and find the task group inspector URLs for releases in flight.
+
+# Actions for Desktop related releases
+
+## Summary
+
+1. Push artifacts to releases directory (also known as mirrors / CDN)
+2. Obtain sign-offs for changes
+3. Publish the release
+4. Post-release steps
+
+Instructions vary slightly depending on the type of release, so please be careful when following the instructions in [[Release Promotion Tasks]]
+
+## Notes and Background
+
+* `-cdntest` and `-localtest` channels serve releases from the releases directory (mirrors or CDN) or candidates directory depending on the release and channel. They are testing channels used before we serve from the _real_ update channel, but they use the _actual files_ that will be served once a release is published.
+* We should notify release-signoff once updates are available on the ${branch}-{cdntest,localtest} channel because we don't have taskcluster email notifications yet.

--- a/docs/release-promotion/mobile/howto.md
+++ b/docs/release-promotion/mobile/howto.md
@@ -1,0 +1,127 @@
+
+## Background
+
+QA will test a potential Fennec release and let us know the results. If the tests all pass, we will have to push the `apk` to Google Play.
+
+To do this we create a new task graph to perform all the release promotion steps. This new graph will pause just before the `push-apk` step in order to allow a human to make the final choice.
+
+## Prerequisites
+
+- VPN Access
+- SSH Access to buildbot-master85
+- (Optional, convenient) [taskcluster-cli](https://github.com/taskcluster/taskcluster-cli) set up
+
+## When to perform these steps
+
+The release-signoff mailing list will receive a message alerting us that testing of Fennec has been completed.
+If the testing is successful, they will ask us to push the result to the Google Play store.
+
+Below is an example email. The key text to look for will be `Testing status:GREEN / DONE` or something similar.
+
+```
+Subject: [mobile] Firefox 58 Beta 5 build 2 - Sign Off of Manual Functional Testing - please push to google play
+
+Hi all,
+
+Here are the results for the Fennec 58 Beta 5 build 2.
+
+Testing status:GREEN / DONE
+*1. Overall build status after testing:* GREEN/OK - No blockers or major 
+bugs found
+
+*2. Recommendation from QE*:  ship to partner's markets
+*3. Manual Testing Summary :*
+*4. New bugs:
+*5. Known Issues:*
+```
+
+## What to do
+
+### Finding the Action Task ID
+
+* Find the `hg revision` of the release in [Ship It](http://ship-it.mozilla.org/), and copy it.
+
+* Run get_graphids.py from releasewarrior-2.0's scripts directory.
+
+```sh
+export REV=.. # Revision from above
+python ./scripts/get_graphids.py --output export --revision ${REV}
+```
+
+### Creating the release promotion graph
+
+1. We will create a new task with the label 'Action: Release Promotion' in the existing on-push graph.
+1. This action will create a new release promotion graph
+
+```sh
+ssh buildbot-master85.bb.releng.scl3.mozilla.com
+sudo su - cltbld
+cd /builds/releaserunner3/
+source bin/activate
+# paste the export line from above, you should have found a
+# decision taskid, and a promote taskid, and a push taskid.
+#   export PROMOTE_TASK_ID=...
+python tools/buildfarm/release/trigger_action.py \
+    ${PROMOTE_TASK_ID+--action-task-id ${PROMOTE_TASK_ID}} \
+    --release-runner-config /builds/releaserunner3/release-runner.yml \
+    --action-flavor ship_fennec
+# Unset ACTION_FLAVOR to minimize the possibility of rerunning with different graph ids
+unset ACTION_FLAVOR
+```
+
+This will show you a task definition and ask if you want to submit it (y/n). If you're ready to ship, choose `y`. The ship action taskId will be near the bottom of the output; this taskId is also used as the task graph ID for the ship graph. 
+
+For example, the last output from `trigger_action.py` will look something like this:
+```O - Result:
+{u'status': {u'workerType': u'gecko-3-decision', u'taskGroupId': u'bjVsVQdfSQWjdq9NTBYySA', u'runs': [{u'scheduled': u'2017-11-21T15:40:38.710Z', u'reasonCreated': u'scheduled', u'state': u'pending', u'runId': 0}], u'expires': u'2018-11-21T15:40:09.109Z', u'retriesLeft': 5, u'state': u'pending', u'schedulerId': u'gecko-level-3', u'deadline': u'2017-11-22T15:40:08.109Z', u'taskId': u'OG1t0QchSj209mV9_3tCHA', u'provisionerId': u'aws-provisioner-v1'}}
+```
+
+We see `u'taskId': u'OG1t0QchSj209mV9_3tCHA'` and know that there should be a task graph with that ID, too. 
+
+```sh
+taskcluster group list OG1t0QchSj209mV9_3tCHA --all
+```
+
+You can also see the new 'Action: Release Promotion' task on [tools.taskcluster.net](https://tools.taskcluster.net/groups)
+
+### Resolve push-apk-breakpoint task
+
+In the new ship graph, there will be a task with 'push-apk-breakpoint' in the label. To push the `apk` to Google Play, we must resolve this task. 
+
+1. Find the Task ID of the `push-apk-breakpoint` task using either [tools.taskcluster.net](https://tools.taskcluster.net/groups) or the taskcluster command-line:
+```sh
+taskcluster group list "${TASKGROUPID}" --all
+```
+1. Complete the push-apk task
+```sh
+taskcluster task complete <TASKID>
+```
+1. The rest of the ship graph should now run, and eventually complete. One of the tasks is a notification, so no email is required to be manually sent.
+
+## Update Releasewarrior
+
+1. Run `release status` to find the incomplete human tasks.
+```sh
+INFO: RELEASE IN FLIGHT: fennec 58.0b5 build2 2017-11-20
+INFO: Graph 1: https://tools.taskcluster.net/task-group-inspector/#/NnPn1IvtQqq9ur84LyqhWg
+INFO: 	Incomplete human tasks:
+INFO: 		* ID 3 (alias: pushapk) - run pushapk
+INFO: 		* ID 4 (alias: publish) - published release tasks
+INFO: 	Unresolved issues:
+```
+2. Resolve the tasks you have performed, using the ID
+```sh
+$ release task fennec 58.0b5 --resolve 3
+INFO: ensuring releasewarrior repo is up to date and in sync with origin
+INFO: generating wiki from template and config
+INFO: writing to data file: /Users/sfraser/github/mozilla-releng/releasewarrior-data/inflight/fennec/fennec-beta-58.0b5.json
+INFO: writing to wiki file: /Users/sfraser/github/mozilla-releng/releasewarrior-data/inflight/fennec/fennec-beta-58.0b5.md
+INFO: writing to corsica file: /Users/sfraser/github/mozilla-releng/releasewarrior-data/index.html
+INFO: committing changes with message: fennec 58.0b5 - updated inflight tasks. Resolved ('3',)
+```
+
+Remember to run `git push` in the `releasewarrior-data` repository, if needed.
+
+
+***
+Last checked: 2017-12-19 by sfraser

--- a/docs/release-promotion/overview.md
+++ b/docs/release-promotion/overview.md
@@ -2,7 +2,7 @@
 
 # Requirements
 
-* All steps followed in the [[ReleaseDuty Day 1 Checklist|ReleaseDuty Day 1 Checklist and FAQ]]
+* All steps followed from Day1 documentation
 * Ability to run the `release` command and find the task group inspector URLs for releases in flight.
 
 # Actions for Desktop related releases
@@ -14,7 +14,7 @@
 3. Publish the release
 4. Post-release steps
 
-Instructions vary slightly depending on the type of release, so please be careful when following the instructions in [[Release Promotion Tasks]]
+Instructions vary slightly depending on the type of release, so please be careful when following the instructions.
 
 ## Notes and Background
 

--- a/docs/signing/Manually-sign-Android-APKs.md
+++ b/docs/signing/Manually-sign-Android-APKs.md
@@ -1,0 +1,87 @@
+
+Currently, two products may need manually signing:
+
+* Firefox Rocket
+* Firefox Focus for Android. :warning: This product has two APKs: one is Focus, the other for the german-speaking population: Klar.
+
+## Requirements
+Google Play refuses non-optimized APKs. The signature changes the structure of the APK archive, which breaks the Zip optimization.
+
+1. Install the latest Android SDK to get the build tools. 
+   * MacOSX: `brew cask install android-sdk` (requires `brew tap caskroom/cask`)
+   * Ubuntu: `apt install android-sdk`
+   * Other: [Install Android Studio](https://developer.android.com/studio/index.html#Other)
+
+## First Steps
+1. `ssh signing4.srv.releng.scl3.mozilla.com`
+1. Change to the `cltsign` user: 
+   ```sh
+   sudo -i
+   su - cltsign
+   ``` 
+   TODO: `sudo -u cltsign` should be enabled.
+
+## To sign an APK 
+You will need to repeat this for each APK, feel free to optimise by downloading all at once, just be careful of filenames when copy/pasting commands.
+
+1. Download unsigned APK(s).
+   * Right-click the attachment in bugzilla and click 'Copy Link Location'
+   * `wget -O unsigned.apk <pasted url>` 
+1. Set environment variables:
+   * For Focus/Klar: 
+     ```sh
+     keystore='/builds/signing/rel-key-signing-server/secrets/focus-jar'
+     alias='focus'
+     ```
+   * For Rocket: 
+     ```sh
+     keystore='/builds/signing/rel-key-signing-server/secrets/rocket-jar'
+     alias='rocket'
+     ```
+1. Look up the right keystore password in the releng private repo
+   * Focus/Klar is under the name `signing-server-focus`
+   * Rocket is under the name `signing-server-rocket`
+1. `jarsigner -keystore "$keystore" unsigned.apk "$alias"`
+   You'll be asked for the password in the previous step. The Klar APK uses the same certificate alias/password as `focus`.
+   You'll also get an expected warning:
+   ```
+   Warning:
+   No -tsa or -tsacert is provided and this jar is not timestamped. Without a timestamp, users may not be able to validate this jar after the signer certificate's expiration date (2044-10-25) or after any future revocation date.
+   ```
+1. `mv unsigned.apk signed.apk`
+1. Verify signatures: `jarsigner -verify -verbose -keystore "$keystore" signed.apk "$alias"`
+1. If your product has several APKs, repeat the previous steps. You may want to give the files more useful names, such as `app-rocket-webkit-release-signed.apk`
+
+## After all the signing
+1. Fetch signed APK(s) on your local machine. You will need to copy the files to your own user account in order to `scp` them, as you can't directly reach the `cltsign` user.
+1. Optimize the APKs for Google Play, and verify. For each APK:
+   ```sh
+   zipalign -v 4 signed.apk signed-aligned.apk
+   zipalign -c -v 4 signed-aligned.apk`
+   ```
+1. Attach the signed and aligned APKs to the bug using the 'attach file' feature in bugzilla.
+
+
+## Troubleshooting
+
+### Can't sign APKs
+
+Sometimes, APKs aren't correctly formatted. For instance, CI may have already signed an APK with a dev key. In this case, you may see:
+```sh
+$ jarsigner -verbose -keystore "$keystore" unsigned.apk "$alias"
+Enter Passphrase for keystore:
+jarsigner: unable to sign jar: java.util.zip.ZipException: invalid entry compressed size (expected 34549 but got 35093 bytes)
+```
+
+The fix is just to strip the signature from the package:
+```sh
+$ zip -d unsigned.apk META-INF/\*
+deleting: META-INF/CERT.RSA
+deleting: META-INF/CERT.SF
+deleting: META-INF/MANIFEST.MF
+```
+
+Then you can resume signing.
+
+
+


### PR DESCRIPTION
The motivation for this PR lies within [this](https://github.com/mozilla-releng/releasewarrior-2.0/issues/61) issue. More information there, but tl:dr:

- we should have our PR mechanism back
- we can make use of branching and other versioning strategies to separate new docs from old
- centralized place that's structured in an easy-to-grasp-and-search way

This PR does:
* moves all the pages from https://github.com/mozilla-releng/releasewarrior-2.0/wiki into a `docs` subfolder in this repo
* updates CHANGELOG with this change since it's a disruptive major change in the workflow of releaseduty
* corrects several hrefs to cope with the new structure
* reorganizes the docs into a logic subdir structure

If this makes sense, the leftovers & follow items are:

1.announce the CHANGELOG use and these changes going on forward to release@
2. Kill the old wiki from https://github.com/mozilla-releng/releasewarrior-2.0/wiki
3. reconsider + filter the old-howtos + sort and move here the old-howtos from https://github.com/mozilla-releng/releasewarrior-2.0/tree/master/old-how-tos too
4. check all href in the documentation to make sure they point to valid homes

Since this is a quite large change, I'll poke more people than usual into the review. 
@mozbhearsum @escapewindow and @lundjordan 