### PR TITLE
fixes non rc templates to point to new docs in-repo location

### DIFF
--- a/releasewarrior/templates/fennec/beta.json.tmpl
+++ b/releasewarrior/templates/fennec/beta.json.tmpl
@@ -19,7 +19,7 @@
             {
                 "alias": "pushapk",
                 "description": "run pushapk",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Push-to-Google-Play#what-to-do",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/docs/release-promotion/mobile/howto.md",
                 "resolved": false
              }
         ],

--- a/releasewarrior/templates/fennec/release.json.tmpl
+++ b/releasewarrior/templates/fennec/release.json.tmpl
@@ -19,7 +19,7 @@
             {
                 "alias": "pushapk",
                 "description": "run pushapk (temp in-tree relpro)",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/old-how-tos/fennec-temp-relpro.md#kick-off-publish-action-task",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/ff91ed12da49e1bfb1cb0b30020eccf4874607cb/old-how-tos/fennec-temp-relpro.md#publish-release",
                 "resolved": false
              }
         ],

--- a/releasewarrior/templates/firefox/beta.json.tmpl
+++ b/releasewarrior/templates/firefox/beta.json.tmpl
@@ -19,19 +19,19 @@
             {
                 "alias": "mirrors",
                 "description": "pushed to mirrors/releases",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks-TC#push-artifacts-to-releases-directory",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/docs/release-promotion/desktop/howto.md#push-artifacts-to-releases-directory",
                 "resolved": false
              },
             {
                 "alias": "publish",
                 "description": "publish release tasks",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks-TC#ship-the-release",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/docs/release-promotion/desktop/howto.md#ship-the-release",
                 "resolved": false
              },
              {
                 "alias": "signoff",
                 "description": "signoff in Balrog",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks-TC#obtain-sign-offs-for-changes",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/docs/release-promotion/desktop/howto.md#obtain-sign-offs-for-changes",
                 "resolved": false
              }
         ],

--- a/releasewarrior/templates/firefox/devedition.json.tmpl
+++ b/releasewarrior/templates/firefox/devedition.json.tmpl
@@ -19,19 +19,19 @@
             {
                 "alias": "mirrors",
                 "description": "pushed to mirrors/releases",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks-TC#push-artifacts-to-releases-directory",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/docs/release-promotion/desktop/howto.md#push-artifacts-to-releases-directory",
                 "resolved": false
             },
             {
                 "alias": "publish",
                 "description": "publish release tasks",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks-TC#publish-the-release",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/docs/release-promotion/desktop/howto.md#ship-the-release",
                 "resolved": false
              },
              {
                 "alias": "signoff",
                 "description": "signoff in Balrog",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks-TC#obtain-sign-offs-for-changes",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/docs/release-promotion/desktop/howto.md#obtain-sign-offs-for-changes",
                 "resolved": false
              }
         ],

--- a/releasewarrior/templates/firefox/release.json.tmpl
+++ b/releasewarrior/templates/firefox/release.json.tmpl
@@ -25,19 +25,19 @@
             {
                 "alias": "mirrors",
                 "description": "pushed to mirrors/releases",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#push-artifacts-to-releases-directory",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/docs/release-promotion/desktop/historic_relpro.md#2-push-to-releases-dir-mirrors",
                 "resolved": false
             },
             {
                 "alias": "publish",
                 "description": "publish release tasks",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#publish-the-release",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/docs/release-promotion/desktop/historic_relpro.md#4-publish-release",
                 "resolved": false
              },
              {
                 "alias": "signoff",
                 "description": "signoff in Balrog",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#obtain-sign-offs-for-changes",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/docs/release-promotion/desktop/historic_relpro.md#3-signoffs",
                 "resolved": false
              }
         ],

--- a/releasewarrior/templates/thunderbird/beta.json.tmpl
+++ b/releasewarrior/templates/thunderbird/beta.json.tmpl
@@ -25,7 +25,7 @@
              {
                 "alias": "signoff",
                 "description": "signoff in Balrog",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#obtain-sign-offs-for-changes",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/docs/release-promotion/desktop/howto.md#obtain-sign-offs-for-changes",
                 "resolved": false
              },
              {

--- a/releasewarrior/templates/thunderbird/release.json.tmpl
+++ b/releasewarrior/templates/thunderbird/release.json.tmpl
@@ -31,7 +31,7 @@
              {
                 "alias": "signoff",
                 "description": "signoff in Balrog",
-                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/wiki/Release-Promotion-Tasks#obtain-sign-offs-for-changes",
+                "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/docs/release-promotion/desktop/howto.md#obtain-sign-offs-for-changes",
                 "resolved": false
              },
              {


### PR DESCRIPTION
This should reflect the truth of today, even if we were to do a dot release before migration, and covers all situations outside of the rc changes in https://github.com/mozilla-releng/releasewarrior-2.0/pull/68