### PR TITLE
add info on how to trigger actions on a newer revision than the builds

### DIFF
--- a/docs/development/Maple-(tc-relpro-development---staging).md
+++ b/docs/development/Maple-(tc-relpro-development---staging).md
@@ -123,6 +123,41 @@ Caveats:
 
 We have a [`params_pre_buildnum`](https://hg.mozilla.org/build/braindump/file/tip/taskcluster/taskgraph-diff/params-pre-buildnum) directory we can use if we're generating task graphs from a pre-[bug 1415391](https://bugzilla.mozilla.org/show_bug.cgi?id=1415391) revision.
 
+## Triggering graphs on separate revisions
+
+Sometimes we land a graph fix on a separate revision from the builds we promoted.
+
+### Command
+
+```bash
+# ship action, after having run both promote and push (RC behavior)
+ssh buildbot-master83.bb.releng.scl3.mozilla.com
+sudo su - cltbld
+cd /builds/releaserunner3/
+source bin/activate
+# set the action task id to the taskId of the most recent relpro action, e.g. push
+ACTION_TASK_ID=Xiz4JZ20SwijU7bXrbVOaw
+ACTION_FLAVOR=ship_firefox
+# use the decision task id *of the revision you want to use to push and ship with*
+DECISION_TASK_ID=VXZvAlW5TMy078ekVwpl_A
+# populate the PREVIOUS_GRAPH_IDS:
+# 1) if the DECISION_TASK_ID is *not* the same as the builds' decision taskId, add that
+# 2) if we ran other actions before ACTION_TASK_ID, add those, in chronological order
+# so PREVIOUS_GRAPH_IDS could look like "BUILD_DECISION_TASK_ID,PROMOTE_ACTION_TASK_ID"
+PREVIOUS_GRAPH_IDS="..."
+python tools/buildfarm/release/trigger_action.py --action-task-id $ACTION_TASK_ID --decision-task-id $DECISION_TASK_ID --previous-graph-ids $PREVIOUS_GRAPH_IDS --release-runner-config /builds/releaserunner3/release-runner.yml --action-flavor $ACTION_FLAVOR
+```
+
+### Concept
+
+We need to use a `--decision-task-id` of the new revision, but we need to include the decision task id of the old revision in `--previous-graph-ids`. Ideally, the order will be
+
+`NEW_REV_DECISION, ORIG_REV_DECISION, PROMOTE, PUSH` if applicable.
+
+We use `--decision-task-id` as the source of truth for `actions.json`, `label-to-taskid.json`, and `parameters.yml`. However, we use `previous_graph_ids` to determine where to take taskIds from for previous graphs (the rightmost takes precedence). So if I want to find the linux64 build taskId, I'd look for it in the `push` graph, fail over to the `promote` graph, then find it in the `ORIG_REV_DECISION` graph.
+
+`trigger_action.py` will prepend the `--decision-task-id` to the beginning of `previous_graph_ids` and append the `--action-task-id` to the end of `previous_graph_ids`. This is what we want; we only have to pass `--previous-graph-ids "ORIG_REV_DECISION,PROMOTE"` for a `ship` action.
+
 ---
 ## debug release promotion action
 


### PR DESCRIPTION
Somewhat rambly and not sure if it's 100% coherent, but it's documented now.