### PR TITLE
Add Fennec release-rc template in config

### DIFF
--- a/releasewarrior/configs/default_config.yaml
+++ b/releasewarrior/configs/default_config.yaml
@@ -35,6 +35,7 @@ templates:
     fennec:
       beta: fennec/beta.json.tmpl
       release: fennec/release.json.tmpl
+      release-rc: fennec/release-rc.json.tmpl
     thunderbird:
       beta: thunderbird/beta.json.tmpl
       release: thunderbird/release.json.tmpl


### PR DESCRIPTION
Even though the template exists, the command `release track fennec 59.0rc` returns:

``` py
WARNING: no release data state file
INFO: ensuring releasewarrior repo is up to date and in sync with upstream
INFO: generating data from template and config
Traceback (most recent call last):
  File "/home/jlorenzo/.virtualenvs/releasewarrior-2.0/bin/release", line 11, in <module>
    load_entry_point('releasewarrior', 'console_scripts', 'release')()
  File "/home/jlorenzo/.virtualenvs/releasewarrior-2.0/lib/python3.6/site-packages/click-6.7-py3.6.egg/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/jlorenzo/.virtualenvs/releasewarrior-2.0/lib/python3.6/site-packages/click-6.7-py3.6.egg/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/jlorenzo/.virtualenvs/releasewarrior-2.0/lib/python3.6/site-packages/click-6.7-py3.6.egg/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/jlorenzo/.virtualenvs/releasewarrior-2.0/lib/python3.6/site-packages/click-6.7-py3.6.egg/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/jlorenzo/.virtualenvs/releasewarrior-2.0/lib/python3.6/site-packages/click-6.7-py3.6.egg/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/jlorenzo/git/mozilla-releng/releasewarrior-2.0/releasewarrior/cli.py", line 72, in track
    data = get_tracking_release_data(release, gtb_date, logger, config)
  File "/home/jlorenzo/git/mozilla-releng/releasewarrior-2.0/releasewarrior/wiki_data.py", line 227, in get_tracking_release_data
    config['templates']["data"][release.product][release.branch]
KeyError: 'release-rc'
```