### PR TITLE
Add documentation for how to interpret update verify results

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,11 @@ This page best serves the people that have previously been into the releaseduty 
 
 _**As releaseduty squirrels are the ones with the best context when it comes to releases, they are the ones to edit this page and amend it accordingly. Keep in mind that changes should be in compliance with the other pieces of documentation.**_
 
+## During 61.0 >= ????
+
+### Changed
+- update verify only blocks on required platforms to start (eg: win32 update verify only blocks on win32 beetmover and balrog)
+
 ## During 60.0 >= 2018-03-13
 
 ### Added
@@ -11,6 +16,7 @@ _**As releaseduty squirrels are the ones with the best context when it comes to 
 ### Changed
 - re-added source tarball for >=60.0b6
 - updated scriptworkers to share more client code
+- update verify now fails on any differences, and creates a summary log for >=60.0b8
 ### Fixed
 - fixed beta+fennec bouncer aliases
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,7 @@ _**As releaseduty squirrels are the ones with the best context when it comes to 
 ### Changed
 - re-added source tarball for >=60.0b6
 - updated scriptworkers to share more client code
-- update verify now fails on any differences, and creates a summary log for >=60.0b8
+- update verify now fails on any differences, and creates a summary log for >=60.0b8. additional documentation on [how to interpret failures](https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/docs/misc-operations/analyze-update-verify-logs.md) are available.
 ### Fixed
 - fixed beta+fennec bouncer aliases
 

--- a/docs/misc-operations/analyze-update-verify-logs.md
+++ b/docs/misc-operations/analyze-update-verify-logs.md
@@ -1,0 +1,52 @@
+# When?
+
+When update verify tasks fail it is your responsibility as releaseduty to analyze them and determine whether or not any action needs to be taken for any differences found.
+
+# How? 
+
+Update verify tasks that have failed should have a "diff-summary.log" in their artifacts. This file shows you all of the differences found for each update tested. In the diffs, `source` is an older version Firefox that a MAR file from the current release has been applied to, and `target` is the full installer for the current release.
+
+Here's an example of a very alarming difference:
+```
+Found diffs for complete update from https://aus5.mozilla.org/update/3/Firefox/59.0/20180215111455/WINNT_x86-msvc/en-US/beta-localtest/default/default/default/update.xml?force=1
+
+Files source/bin/xul.dll and target/bin/xul.dll differ
+```
+
+In the above log, `xul.dll' is shown to be different between an applied MAR and a full installer. If we were to ship a release with a difference like this, partial MARs would fail to apply for many users in the _next_ release. Usually a case like this represents an issue in the build system or release automation, and requires a rebuild. If you're not sure how to proceed, ask for help.
+
+If no diff-summary.log is attached to the Task something more serious went wrong. You will need to have a look at live.log to investigate.
+
+# Known differences
+
+There are a few known cases where diffs are expected, and ignorable.
+
+## Beta channel/ACCEPTED_MAR_CHANNEL_IDS during secondary update verify in RCs
+
+```
+Found diffs for complete update from https://aus5.mozilla.org/update/3/Firefox/59.0/20180215111455/Linux_x86-gcc3/en-US/beta-localtest/default/default/default/update.xml?force=1
+diff -r source/firefox/defaults/pref/channel-prefs.js target/firefox/defaults/pref/channel-prefs.js
+5c5
+< pref("app.update.channel", "beta");
+---
+> pref("app.update.channel", "release");
+diff -r source/firefox/update-settings.ini target/firefox/update-settings.ini
+5c5
+< ACCEPTED_MAR_CHANNEL_IDS=firefox-mozilla-beta,firefox-mozilla-release
+---
+> ACCEPTED_MAR_CHANNEL_IDS=firefox-mozilla-release
+```
+
+The differences shown tell us that when a user is running Beta and applies an RC MAR file, they end up with the same Firefox that a fresh RC install does, except they maintain their Beta update channel and ACCEPTED_MAR_CHANNEL_IDS. This is expected and OK (if we didn't have this diff, it would mean that we switched Beta users to the release channel!).
+
+## channel-prefs.js comment changes
+
+```
+diff -r source/Firefox.app/Contents/Resources/defaults/pref/channel-prefs.js target/Firefox.app/Contents/Resources/defaults/pref/channel-prefs.js^M
+5d4^M
+< //@line 6 "/builds/worker/workspace/build/src/browser/app/profile/channel-prefs.js"^M
+```
+
+channel-prefs.js contains comments that have the full path to a file in the build directory. If the build directory changes between a previous version and the latest version, this will show up as a difference in update verify. Being a comment change, this is totally ignorable.
+
+Newer versions of Firefox have removed this comment from channel-prefs.js, so this difference should go away entirely after the next round of watersheds.

--- a/docs/misc-operations/analyze-update-verify-logs.md
+++ b/docs/misc-operations/analyze-update-verify-logs.md
@@ -4,7 +4,7 @@ When update verify tasks fail it is your responsibility as releaseduty to analyz
 
 # How? 
 
-Update verify tasks that have failed should have a "diff-summary.log" in their artifacts. This file shows you all of the differences found for each update tested. In the diffs, `source` is an older version Firefox that a MAR file from the current release has been applied to, and `target` is the full installer for the current release.
+Update verify tasks that have failed should have a `diff-summary.log` in their artifacts. This file shows you all of the differences found for each update tested. In the diffs, `source` is an older version Firefox that a MAR file from the current release has been applied to, and `target` is the full installer for the current release.
 
 Here's an example of a very alarming difference:
 ```
@@ -13,9 +13,9 @@ Found diffs for complete update from https://aus5.mozilla.org/update/3/Firefox/5
 Files source/bin/xul.dll and target/bin/xul.dll differ
 ```
 
-In the above log, `xul.dll' is shown to be different between an applied MAR and a full installer. If we were to ship a release with a difference like this, partial MARs would fail to apply for many users in the _next_ release. Usually a case like this represents an issue in the build system or release automation, and requires a rebuild. If you're not sure how to proceed, ask for help.
+In the above log, `xul.dll` is shown to be different between an applied MAR and a full installer. If we were to ship a release with a difference like this, partial MARs would fail to apply for many users in the _next_ release. Usually a case like this represents an issue in the build system or release automation, and requires a rebuild. If you're not sure how to proceed, ask for help.
 
-If no diff-summary.log is attached to the Task something more serious went wrong. You will need to have a look at live.log to investigate.
+If no `diff-summary.log` is attached to the Task something more serious went wrong. You will need to have a look at live.log to investigate.
 
 # Known differences
 
@@ -47,6 +47,6 @@ diff -r source/Firefox.app/Contents/Resources/defaults/pref/channel-prefs.js tar
 < //@line 6 "/builds/worker/workspace/build/src/browser/app/profile/channel-prefs.js"^M
 ```
 
-channel-prefs.js contains comments that have the full path to a file in the build directory. If the build directory changes between a previous version and the latest version, this will show up as a difference in update verify. Being a comment change, this is totally ignorable.
+`channel-prefs.js` contains comments that have the full path to a file in the build directory. If the build directory changes between a previous version and the latest version, this will show up as a difference in update verify. Being a comment change, this is totally ignorable.
 
-Newer versions of Firefox have removed this comment from channel-prefs.js, so this difference should go away entirely after the next round of watersheds.
+Newer versions of Firefox have removed this comment from `channel-prefs.js`, so this difference should go away entirely after the next round of watersheds.

--- a/docs/misc-operations/analyze-update-verify-logs.md
+++ b/docs/misc-operations/analyze-update-verify-logs.md
@@ -4,7 +4,7 @@ When update verify tasks fail it is your responsibility as releaseduty to analyz
 
 # How? 
 
-Update verify tasks that have failed should have a `diff-summary.log` in their artifacts. This file shows you all of the differences found for each update tested. In the diffs, `source` is an older version Firefox that a MAR file from the current release has been applied to, and `target` is the full installer for the current release.
+Update verify tasks that have failed usually have a `diff-summary.log` in their artifacts. This file shows you all of the differences found for each update tested. In the diffs, `source` is an older version Firefox that a MAR file from the current release has been applied to, and `target` is the full installer for the current release.
 
 Here's an example of a very alarming difference:
 ```

--- a/docs/misc-operations/analyze-update-verify-logs.md
+++ b/docs/misc-operations/analyze-update-verify-logs.md
@@ -19,7 +19,7 @@ If no `diff-summary.log` is attached to the Task something more serious went wro
 
 # Known differences
 
-There are a few known cases where diffs are expected, and ignorable.
+There are two known cases where diffs are expected, and ignorable.
 
 ## Beta channel/ACCEPTED_MAR_CHANNEL_IDS during secondary update verify in RCs
 


### PR DESCRIPTION
This is related to https://bugzilla.mozilla.org/show_bug.cgi?id=1446160, where I've made update verify fail more aggressively, and generate a summary log.

@escapewindow - it's probably good for you to have a look at this too, since you're on releaseduty.