### PR TITLE
Allow pasting of urls for task groups and bugs

### DIFF
--- a/releasewarrior/click_input.py
+++ b/releasewarrior/click_input.py
@@ -28,6 +28,8 @@ def generate_prereq_task_from_input(gtb_date=None):
 def generate_inflight_issue_from_input():
     who = click.prompt('Who', type=str, default=getpass.getuser())
     bug = click.prompt('Bug number if exists', type=str, default="none")
+    # Turn pasted bugzilla url into a bug number
+    bug = bug.split('=')[-1]
     description = click.prompt('Description of issue', type=str)
     return Issue(who, bug, description, resolved=False, future_threat=True)
 

--- a/releasewarrior/wiki_data.py
+++ b/releasewarrior/wiki_data.py
@@ -337,6 +337,8 @@ def update_inflight_issue(data, resolve, logger):
 def update_inflight_graphid(data, phase, graphid, logger):
     data = deepcopy(data)
     current_build_index = get_current_build_index(data)
+    # If we've been given a url, copy/pasted from the 'new build' email, fix that.
+    graphid = graphid.split('/')[-1]
     graphids = data["inflight"][current_build_index]["graphids"]
     existing_phases = [p for p, _ in graphids]
     if phase in existing_phases:


### PR DESCRIPTION
Do the right thing if you 'copy link' from the new build email, or copy/paste a bugzilla link.