### PR TITLE
Revert "Rename 'pushapk' to 'ship' for Fennec, for consistent naming"

### DIFF
--- a/docs/release-promotion/mobile/howto-rc.md
+++ b/docs/release-promotion/mobile/howto-rc.md
@@ -141,7 +141,7 @@ You can also see the new 'Action: Release Promotion' task on [tools.taskcluster.
 INFO: RELEASE IN FLIGHT: fennec 60.0 build2 2017-11-20
 INFO: Graph 1: https://tools.taskcluster.net/task-group-inspector/#/NnPn1IvtQqq9ur84LyqhWg
 INFO: 	Incomplete human tasks:
-INFO: 		* ID 3 (alias: ship) - Push APK to play store
+INFO: 		* ID 3 (alias: pushapk) - run pushapk
 INFO: 		* ID 4 (alias: publish) - published release tasks
 INFO: 	Unresolved issues:
 ```

--- a/docs/release-promotion/mobile/howto.md
+++ b/docs/release-promotion/mobile/howto.md
@@ -3,7 +3,7 @@
 
 QA will test a potential Fennec release and let us know the results. If the tests all pass, we will have to push the `apk` to Google Play.
 
-To do this we create a new task graph to perform all the release promotion steps.
+To do this we create a new task graph to perform all the release promotion steps. 
 
 ## Prerequisites
 
@@ -85,7 +85,7 @@ You can also see the new 'Action: Release Promotion' task on [tools.taskcluster.
 INFO: RELEASE IN FLIGHT: fennec 58.0b5 build2 2017-11-20
 INFO: Graph 1: https://tools.taskcluster.net/task-group-inspector/#/NnPn1IvtQqq9ur84LyqhWg
 INFO: 	Incomplete human tasks:
-INFO: 		* ID 3 (alias: ship) - Push APK to Play store
+INFO: 		* ID 3 (alias: pushapk) - run pushapk
 INFO: 		* ID 4 (alias: publish) - published release tasks
 INFO: 	Unresolved issues:
 ```

--- a/releasewarrior/templates/corsica/fennec_beta_progress.template.html
+++ b/releasewarrior/templates/corsica/fennec_beta_progress.template.html
@@ -5,17 +5,17 @@
 {% else %}
   <div class="progress-bar bg-white text-muted" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">Release kick off</div>
 {% endif %}
-{% if releases["fennec"]["beta"]["human_tasks"]["ship"] %}
+{% if releases["fennec"]["beta"]["human_tasks"]["pushapk"] %}
   <div class="progress-bar bg-primary" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">Uploaded builds</div>
 {% else %}
   <div class="progress-bar bg-white text-muted" role="progressbar" style="width: 25%" aria-valuenow="225 aria-valuemin="0" aria-valuemax="100">Upload builds</div>
 {% endif %}
-{% if releases["fennec"]["beta"]["human_tasks"]["ship"] %}
+{% if releases["fennec"]["beta"]["human_tasks"]["pushapk"] %}
   <div class="progress-bar bg-primary" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">QE signed off</div>
 {% else %}
   <div class="progress-bar bg-white text-muted" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">QE sign off</div>
 {% endif %}
-{% if releases["fennec"]["beta"]["human_tasks"]["ship"] %}
+{% if releases["fennec"]["beta"]["human_tasks"]["pushapk"] %}
   <div class="progress-bar bg-primary" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">Published on Google Play</div>
 {% else %}
   <div class="progress-bar bg-white text-muted" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">Publish on Google Play</div>

--- a/releasewarrior/templates/fennec/beta.json.tmpl
+++ b/releasewarrior/templates/fennec/beta.json.tmpl
@@ -17,8 +17,8 @@
                 "resolved": false
             },
             {
-                "alias": "ship",
-                "description": "Push APK to Play store",
+                "alias": "pushapk",
+                "description": "run pushapk",
                 "docs": "https://github.com/mozilla-releng/releasewarrior-2.0/blob/master/docs/release-promotion/mobile/howto.md",
                 "resolved": false
              }


### PR DESCRIPTION
Reverts mozilla-releng/releasewarrior-2.0#137

As it failed in warrior with the following error:

```
(releasewarrior) mtabara@mozspace:[master]~/work/mozilla/clones/git/releasewarrior-2.0$ release track firefox 60.0.2esr
WARNING: no release data state file
INFO: ensuring releasewarrior repo is up to date and in sync with mozilla
INFO: generating data from template and config
INFO: generating wiki from template and config
INFO: writing to data file: /Users/mtabara/work/mozilla/clones/git/releasewarrior-data/upcoming/firefox/firefox-esr60-60.0.2esr.json
INFO: writing to wiki file: /Users/mtabara/work/mozilla/clones/git/releasewarrior-data/upcoming/firefox/firefox-esr60-60.0.2esr.md
INFO: writing to wiki file: /Users/mtabara/work/mozilla/clones/git/releasewarrior-data/README.md
Traceback (most recent call last):
  File "/Users/mtabara/envs/releasewarrior/bin/release", line 11, in <module>
    load_entry_point('releasewarrior', 'console_scripts', 'release')()
  File "/Users/mtabara/envs/releasewarrior/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/mtabara/envs/releasewarrior/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/mtabara/envs/releasewarrior/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/mtabara/envs/releasewarrior/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/mtabara/envs/releasewarrior/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/mtabara/work/mozilla/clones/git/releasewarrior-2.0/releasewarrior/cli.py", line 74, in track
    write_and_commit(data, data_path, wiki_path, commit_msg, logger, config)
  File "/Users/mtabara/work/mozilla/clones/git/releasewarrior-2.0/releasewarrior/wiki_data.py", line 196, in write_and_commit
    corsica = generate_corsica(config, logger)
  File "/Users/mtabara/work/mozilla/clones/git/releasewarrior-2.0/releasewarrior/wiki_data.py", line 160, in generate_corsica
    return template.render(**corsica_data)
  File "/Users/mtabara/envs/releasewarrior/lib/python3.6/site-packages/jinja2/asyncsupport.py", line 76, in render
    return original_render(self, *args, **kwargs)
  File "/Users/mtabara/envs/releasewarrior/lib/python3.6/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/Users/mtabara/envs/releasewarrior/lib/python3.6/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/mtabara/envs/releasewarrior/lib/python3.6/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "/Users/mtabara/work/mozilla/clones/git/releasewarrior-2.0/releasewarrior/templates/corsica/index.template.html", line 85, in top-level template code
    {{ beta_status()|indent(4) }}
  File "/Users/mtabara/envs/releasewarrior/lib/python3.6/site-packages/jinja2/runtime.py", line 553, in _invoke
    rv = self._func(*arguments)
  File "/Users/mtabara/work/mozilla/clones/git/releasewarrior-2.0/releasewarrior/templates/corsica/index.template.html", line 83, in template
    {% include "corsica/fennec_beta_progress.template.html" %}
  File "/Users/mtabara/work/mozilla/clones/git/releasewarrior-2.0/releasewarrior/templates/corsica/fennec_beta_progress.template.html", line 8, in top-level template code
    {% if releases["fennec"]["beta"]["human_tasks"]["ship"] %}
jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'ship'
```