### PR TITLE
Pull commits from upsteam instead of fetch

### DIFF
--- a/releasewarrior/helpers.py
+++ b/releasewarrior/helpers.py
@@ -212,7 +212,7 @@ def validate_data_repo_updated(logger, config):
     # TODO - we should allow csets to exist locally that are not on remote.
     logger.info("ensuring releasewarrior repo is up to date and in sync with {}".format(upstream))
     logger.debug('pulling new csets from {}/master'.format(upstream))
-    upstream.pull()
+    upstream.pull(rebase=True)
     commits_behind = list(repo.iter_commits('master..{}/master'.format(upstream)))
     if commits_behind:
         logger.fatal('local master is behind {}/master.'.format(upstream))

--- a/releasewarrior/helpers.py
+++ b/releasewarrior/helpers.py
@@ -206,12 +206,13 @@ def validate(release, logger, config, must_exist=False, must_exist_in=None):
 def validate_data_repo_updated(logger, config):
     repo = Repo(config['releasewarrior_data_repo'])
     if repo.is_dirty():
-        logger.warning("release data repo dirty")
+        logger.fatal("release data repo dirty. Aborting...")
+        return False
     upstream = find_upstream_repo(repo, logger, config)
     # TODO - we should allow csets to exist locally that are not on remote.
     logger.info("ensuring releasewarrior repo is up to date and in sync with {}".format(upstream))
-    logger.debug('fetching new csets from {}/master'.format(upstream))
-    upstream.fetch()
+    logger.debug('pulling new csets from {}/master'.format(upstream))
+    upstream.pull()
     commits_behind = list(repo.iter_commits('master..{}/master'.format(upstream)))
     if commits_behind:
         logger.fatal('local master is behind {}/master.'.format(upstream))

--- a/releasewarrior/helpers.py
+++ b/releasewarrior/helpers.py
@@ -212,7 +212,13 @@ def validate_data_repo_updated(logger, config):
     # TODO - we should allow csets to exist locally that are not on remote.
     logger.info("ensuring releasewarrior repo is up to date and in sync with {}".format(upstream))
     logger.debug('pulling new csets from {}/master'.format(upstream))
-    upstream.pull(rebase=True)
+    try:
+        upstream.pull(rebase=True)
+    except git_exc.GitCommandError:
+        logger.fatal(
+            'Could not rebase the repo on top of {}/master. Please run `git rebase --abort` then \
+resolve the conflicts manually'.format(upstream)
+        )
     commits_behind = list(repo.iter_commits('master..{}/master'.format(upstream)))
     if commits_behind:
         logger.fatal('local master is behind {}/master.'.format(upstream))

--- a/releasewarrior/helpers.py
+++ b/releasewarrior/helpers.py
@@ -213,11 +213,11 @@ def validate_data_repo_updated(logger, config):
     logger.info("ensuring releasewarrior repo is up to date and in sync with {}".format(upstream))
     logger.debug('pulling new csets from {}/master'.format(upstream))
     try:
-        upstream.pull(rebase=True)
-    except git_exc.GitCommandError:
+        # XXX ff_only=True is overriden by user's gitconfig. Known case: when user set rebase = true
+        upstream.pull(ff_only=True)
+    except git_exc.GitCommandError as e:
         logger.fatal(
-            'Could not rebase the repo on top of {}/master. Please run `git rebase --abort` then \
-resolve the conflicts manually'.format(upstream)
+            'Could not pull changes from {}/master: {}'.format(upstream, e)
         )
     commits_behind = list(repo.iter_commits('master..{}/master'.format(upstream)))
     if commits_behind:


### PR DESCRIPTION
Fixes #17 

Today, I came across several commands that didn't pass because the repo wasn't updated. I hadn't realized it went wrong until I `release status`d. @lundjordan do you think we're comfortable enough to make `pull` the default behavior? 